### PR TITLE
ci: #7 exclude CHANGELOG.md from markdown lint workflow

### DIFF
--- a/.github/workflows/lint-md.yml
+++ b/.github/workflows/lint-md.yml
@@ -21,3 +21,4 @@ jobs:
           globs: |
             **/*.md
             #node_modules
+            #CHANGELOG.md


### PR DESCRIPTION
## Summary

- Aligns the `Lint Markdown` workflow's globs with `package.json`'s `lint:md` script so CI no longer fails on the baseline `CHANGELOG.md` MD012 violation that Release Please emits on every release.

## Linked issue

Closes #7

## Branch state

- Latest pushed branch state: `7-lint-markdown-baseline@ff9609e`
- Review state: no open findings
- CI state: pending at PR creation; expected to pass

## Acceptance criteria

### AC-7-1
The `Lint Markdown` workflow succeeds on PRs that do not touch `CHANGELOG.md`.
- [x] Verification: `pnpm lint:md` locally — exit 0, 0 errors across 23 files (matches the new CI glob).

### AC-7-2
Release Please's next release PR does not fail `Lint Markdown` because of generator-emitted blank lines.
- [ ] Verification: deferred — confirmed at the next Release Please run.

### AC-7-3
Local `pnpm lint:md` and CI `Lint Markdown` agree on pass/fail outcomes.
- [x] Verification: workflow globs (`**/*.md`, `#node_modules`, `#CHANGELOG.md`) now match the local script's globs in `package.json`.

## Test plan

- [x] All required ACs above verified on the latest pushed branch state.
- [x] Verification reflects the current branch state, not superseded local work.

## Review follow-up

- Local reviewer state: none
- External feedback state: no open review threads
- Branch-state-aware next action: monitor CI on `ff9609e`; once green and merged, rebase or push #6 to clear its baseline failure.
