### PR TITLE
fix: #9 improve Codex skill display names

### DIFF
--- a/skills/edit-issue/agents/openai.yaml
+++ b/skills/edit-issue/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Edit Issue"
+  short_description: "Edit GitHub issue fields and relationships"
+  default_prompt: "Use $edit-issue to update an existing GitHub issue with validated fields, labels, milestone, state, close reason, or relationships."

--- a/skills/new-branch/agents/openai.yaml
+++ b/skills/new-branch/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "New Branch"
+  short_description: "Create an issue branch from the default branch"
+  default_prompt: "Use $new-branch to resolve a GitHub issue, create the matching issue branch, rebase it on the default branch, and install dependencies."

--- a/skills/new-issue/agents/openai.yaml
+++ b/skills/new-issue/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "New Issue"
+  short_description: "File a structured GitHub issue"
+  default_prompt: "Use $new-issue to draft, validate, and file a new GitHub issue with labels, duplicate checks, and public-repo leak protection."

--- a/skills/write-changelog/agents/openai.yaml
+++ b/skills/write-changelog/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Write Changelog"
+  short_description: "Render release notes from a milestone"
+  default_prompt: "Use $write-changelog to render a user-facing changelog block from a GitHub milestone and its merged pull requests."


### PR DESCRIPTION
## Summary

- Add Codex-specific `agents/openai.yaml` metadata for each github-flows skill.
- Set display names to `New Issue`, `Edit Issue`, `New Branch`, and `Write Changelog` while preserving existing kebab-case skill names and slash-command docs.

## Linked issue

- Closes #9

## Acceptance criteria

### AC-9-1

Codex skill display metadata now supplies bare skill names without the visible `GitHub Flows:` namespace prefix.

- [x] Metadata evidence — ruby `Psych.load_file` assertion for no `:` and no `GitHub Flows` prefix in display names | local worktree | @codex | 2026-04-26T12:41:16Z
- [ ] ⚠️ E2E gap: Automated verification confirms the shipped metadata shape, but the live Codex skill palette must be reloaded from an installed plugin to visually confirm runtime rendering.
- [ ] Manual test: 1. Install this branch's plugin in Codex. 2. Open the skill picker. 3. Confirm the four github-flows entries appear without `GitHub Flows:` in front.

### AC-9-2

Each github-flows Codex display name is Title Case.

- [x] Metadata evidence — ruby `Psych.load_file` assertion matched `New Issue`, `Edit Issue`, `New Branch`, and `Write Changelog` exactly | local worktree | @codex | 2026-04-26T12:41:16Z
- [ ] Manual test: 1. Install this branch's plugin in Codex. 2. Open the skill picker. 3. Confirm the visible names are `New Issue`, `Edit Issue`, `New Branch`, and `Write Changelog`.

### AC-9-3

Existing slash-command documentation remains accurate because the canonical `SKILL.md` `name:` values and workflow docs were not changed.

- [x] Diff evidence — reviewed staged diff containing only new `skills/*/agents/openai.yaml` files and no workflow or README invocation changes | local worktree | @codex | 2026-04-26T12:41:16Z

## Validation

- `pnpm install`
- `pnpm lint:md`
- `node scripts/check-plugin-versions.mjs`
- `ruby -e 'require "psych"; expected={"skills/new-issue/agents/openai.yaml"=>"New Issue","skills/edit-issue/agents/openai.yaml"=>"Edit Issue","skills/new-branch/agents/openai.yaml"=>"New Branch","skills/write-changelog/agents/openai.yaml"=>"Write Changelog"}; expected.each{|path,name| data=Psych.load_file(path); actual=data.fetch("interface").fetch("display_name"); abort("#{path}: expected #{name.inspect}, got #{actual.inspect}") unless actual==name; abort("#{path}: display name still contains namespace") if actual.include?(":") || actual.start_with?("GitHub Flows")}; puts "Codex display metadata OK"'`

## Docs updated

- [x] Not needed
- [ ] Updated in this PR
