### PR TITLE
docs: #13 use remote labels for new issues

### DIFF
--- a/docs/issue-filing-style.md
+++ b/docs/issue-filing-style.md
@@ -2,7 +2,7 @@
 
 This is the canonical guide for filing GitHub issues in `patinaproject/github-flows`. The `/github-flows:new-issue` skill reads this document at runtime and uses it as the single source of truth for body shape, AC format, label/milestone/relationship conventions, and the public-repo leak guard. Contributors filing issues by hand should follow the same rules.
 
-For the label inventory, see [`../.github/LABELS.md`](../.github/LABELS.md).
+For the label inventory, run `gh label list --json name,description`.
 
 ## Body template
 
@@ -60,9 +60,12 @@ PR titles **do** follow the commitlint format (`type: #<issue> short description
 
 ## Labels
 
-The label inventory lives in [`.github/LABELS.md`](../.github/LABELS.md). When filing or editing issues:
+The label inventory comes from the remote repository via
+`gh label list --json name,description`. When filing or editing issues:
 
 - Pick from descriptions, never from memory.
+- A local `.github/LABELS.md` file may document labels for humans, but skills
+  must not require it.
 - Zero labels is valid — do not block on label selection.
 - `autorelease: pending` and `autorelease: tagged` are reserved for Release Please. Never apply them manually.
 - `javascript` and `github_actions` (Dependabot-reserved) are not user-applicable.

--- a/docs/superpowers/plans/2026-04-27-13-new-issue-should-work-without-labels-md-plan.md
+++ b/docs/superpowers/plans/2026-04-27-13-new-issue-should-work-without-labels-md-plan.md
@@ -1,0 +1,156 @@
+# /new-issue should work without LABELS.md Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `/github-flows:new-issue` load labels from GitHub through `gh label list` instead of requiring local `.github/LABELS.md`.
+
+**Architecture:** This is a documentation and workflow-contract change. The runtime contract in `skills/new-issue/workflow.md` becomes the source for agent behavior, while `docs/issue-filing-style.md` stays aligned for contributors and future skill runs.
+
+**Tech Stack:** Markdown, GitHub CLI, markdownlint-cli2, repository Husky hooks.
+
+---
+
+## File Structure
+
+- Modify `skills/new-issue/workflow.md`: replace the `.github/LABELS.md` parser contract with remote label loading, update Step 8 validation, and update refusal/reference tables.
+- Modify `docs/issue-filing-style.md`: replace mandatory local label-inventory language with `gh label list` guidance and mark `.github/LABELS.md` optional for skills.
+- Use existing verification commands only; no new scripts or executable tooling.
+
+## Task 1: Update `/new-issue` Label Inventory Workflow
+
+**Files:**
+
+- Modify: `skills/new-issue/workflow.md`
+
+- [ ] **Step 1: Write the workflow-contract pressure check**
+
+  Before editing, record the stale mandatory local-label references:
+
+  ```bash
+  rg -n 'LABELS\.md table|LABELS\.md` not found|Read `?\.github/LABELS\.md|from \.github/LABELS\.md|in `\.github/LABELS\.md`' skills/new-issue/workflow.md
+  ```
+
+  Expected: matches in Step 1 and the refusal/quick-reference sections, proving the workflow currently blocks on `.github/LABELS.md`.
+
+- [ ] **Step 2: Replace Step 1 with remote label loading**
+
+  In `skills/new-issue/workflow.md`, change authoritative inputs and Step 1 so the workflow runs:
+
+  ```bash
+  gh label list --json name,description --jq '.'
+  ```
+
+  Required behavior text:
+
+  - halt if the command fails, JSON is malformed, the list is empty, or any label has an empty `name`
+  - warn but continue if descriptions are empty
+  - derive label names from `gh label list` every run
+  - state that local `.github/LABELS.md` is optional documentation and must not block issue creation
+
+- [ ] **Step 3: Update Step 8 label validation**
+
+  In `skills/new-issue/workflow.md`, make pre-creation validation reuse the Step 1 remote inventory or refresh with:
+
+  ```bash
+  gh label list --json name --jq '.[].name'
+  ```
+
+  Required refusal:
+
+  ```text
+  Label `{label}` does not exist on the remote repo. Run `gh label create {label} ...` first, or remove it from the selection.
+  ```
+
+- [ ] **Step 4: Update refusal and reference tables**
+
+  In `skills/new-issue/workflow.md`, update the refusal condition, quick reference, and common mistakes table so they mention `gh label list` rather than mandatory `.github/LABELS.md`.
+
+## Task 2: Align Issue Filing Guidance
+
+**Files:**
+
+- Modify: `docs/issue-filing-style.md`
+
+- [ ] **Step 1: Update label source guidance**
+
+  Replace local-label source text with:
+
+  ```markdown
+  For the label inventory, run `gh label list --json name,description`.
+  ```
+
+- [ ] **Step 2: Update the Labels section**
+
+  Make the section say the inventory comes from the remote repository via:
+
+  ```bash
+  gh label list --json name,description
+  ```
+
+  Add a bullet that local `.github/LABELS.md` may document labels for humans, but skills must not require it.
+
+## Task 3: Verify Workflow Contract
+
+**Files:**
+
+- Verify: `skills/new-issue/workflow.md`
+- Verify: `docs/issue-filing-style.md`
+
+- [ ] **Step 1: Search for stale mandatory local-label language**
+
+  ```bash
+  rg -n 'LABELS\.md table|LABELS\.md is missing|Read \.github/LABELS\.md|from \.github/LABELS\.md|in `\.github/LABELS\.md`|\.github/LABELS\.md` not found' skills/new-issue/workflow.md docs/issue-filing-style.md
+  ```
+
+  Expected: no matches.
+
+- [ ] **Step 2: Verify the remote label command**
+
+  ```bash
+  gh label list --json name,description --jq 'length'
+  ```
+
+  Expected: exits 0 and prints a positive integer.
+
+- [ ] **Step 3: Run markdown and whitespace checks**
+
+  ```bash
+  pnpm lint:md
+  git diff --check
+  ```
+
+  Expected: both commands exit 0.
+
+- [ ] **Step 4: Commit implementation**
+
+  ```bash
+  git add skills/new-issue/workflow.md docs/issue-filing-style.md
+  git commit -m "docs: #13 use remote labels for new issues"
+  ```
+
+## Task 4: Reviewer Pressure Test
+
+**Files:**
+
+- Review: `skills/new-issue/workflow.md`
+- Review: `docs/issue-filing-style.md`
+
+- [ ] **Step 1: Run missing-LABELS.md walkthrough**
+
+  Read Step 1 and confirm that a repository with no `.github/LABELS.md` but a working `gh label list` command proceeds to Step 2.
+
+- [ ] **Step 2: Run chosen-label walkthrough**
+
+  Read Step 8 and confirm that a chosen label is checked against the remote list and a missing label produces the remote-repo refusal.
+
+- [ ] **Step 3: Run zero-label walkthrough**
+
+  Confirm Step 4 and Step 9 still allow no selected labels and only print the existing advisory.
+
+- [ ] **Step 4: Commit reviewer fixes only if needed**
+
+  If the walkthrough finds a loophole, patch it, rerun Task 3 verification, and commit with:
+
+  ```bash
+  git commit -m "docs: #13 tighten new issue label workflow"
+  ```

--- a/docs/superpowers/specs/2026-04-27-13-new-issue-should-work-without-labels-md-design.md
+++ b/docs/superpowers/specs/2026-04-27-13-new-issue-should-work-without-labels-md-design.md
@@ -1,0 +1,78 @@
+# Design: /new-issue should work without LABELS.md [#13](https://github.com/patinaproject/github-flows/issues/13)
+
+## Intent
+
+Make `/github-flows:new-issue` usable in repositories that do not carry a local
+`.github/LABELS.md` file. The workflow should rely on GitHub's remote label
+inventory via `gh label list`, matching the repository guidance that label
+descriptions on the remote are the canonical source for selection.
+
+## Requirements
+
+- `skills/new-issue/workflow.md` must no longer halt when `.github/LABELS.md`
+  is absent.
+- Step 1 must load labels with `gh label list --json name,description`.
+- Label suggestion guidance must use remote label descriptions and continue to
+  treat zero selected labels as a valid path.
+- Pre-creation label validation must check chosen labels against the remote
+  label inventory, not against local label documentation.
+- Local `.github/LABELS.md` may remain as human-facing documentation, but the
+  skill must describe it as optional.
+- `docs/issue-filing-style.md` must align with the runtime workflow and tell
+  contributors that skills use `gh label list`.
+- Dependabot-only and Release Please-reserved label rules stay unchanged.
+
+## Design
+
+Update Step 1 of `skills/new-issue/workflow.md` from a Markdown-table parser to
+a remote inventory fetch:
+
+```bash
+gh label list --json name,description --jq '.'
+```
+
+The workflow validates that the command succeeds, the JSON parses, the list is
+non-empty, and every returned label has a non-empty `name`. Empty label
+descriptions should warn rather than block, because AGENTS.md asks contributors
+to verify descriptions but the issue-filing flow should still be able to proceed
+when a repository has imperfect metadata.
+
+The Step 8 remote label existence check should reuse the Step 1 inventory, or
+refresh with `gh label list --json name --jq '.[].name'` if needed. The refusal
+message should say the label does not exist on the remote repository, with no
+reference to `.github/LABELS.md`.
+
+`docs/issue-filing-style.md` should describe `gh label list --json
+name,description` as the runtime source of truth and note that `.github/LABELS.md`
+is optional documentation only.
+
+## Acceptance Criteria
+
+- AC-13-1: Given a repository with remote GitHub labels and no local
+  `.github/LABELS.md`, when an agent follows `/github-flows:new-issue`, then
+  Step 1 loads labels through `gh label list` and does not halt on the missing
+  file.
+- AC-13-2: Given a user-selected label, when `/github-flows:new-issue` performs
+  pre-creation checks, then it validates the label against the remote label list
+  and reports missing labels as absent from the remote repository.
+- AC-13-3: Given repository documentation for issue filing, when contributors
+  read the label guidance, then it points to `gh label list --json
+  name,description` and says `.github/LABELS.md` is optional for skills.
+- AC-13-4: Given this is a workflow-contract change, when review runs, then the
+  reviewer performs a pressure-test walkthrough covering the missing
+  `.github/LABELS.md` path.
+
+## Verification
+
+- Run `pnpm lint:md`.
+- Run `git diff --check`.
+- Run `gh label list --json name,description --jq 'length'` from the repository
+  root to verify the remote label command works.
+- Search changed docs for stale mandatory `.github/LABELS.md` halt language.
+
+## Out of Scope
+
+- Removing `.github/LABELS.md` from this repository.
+- Synchronizing local label documentation with GitHub labels.
+- Changing label names, colors, or descriptions on GitHub.
+- Changing `/github-flows:edit-issue`, which already uses `gh label list`.

--- a/skills/new-issue/workflow.md
+++ b/skills/new-issue/workflow.md
@@ -4,7 +4,7 @@
 `docs/issue-filing-style.md` as the single source of truth for issue-filing
 conventions, while this workflow retains the procedural `gh`-driven steps.
 Authoritative inputs: `docs/issue-filing-style.md` for filing policy and
-`.github/LABELS.md` for the canonical label inventory.
+`gh label list` for the canonical remote label inventory.
 
 This workflow is an extension of the patinaproject `/new-issue` reference. It
 adds two behaviors: a **duplicate check** (Step 3) and a **public-repo leak
@@ -16,7 +16,7 @@ guard** (sub-step inside Steps 7 and 8).
 
 Create todos for each step before starting:
 
-- [ ] Step 1: Load label list from .github/LABELS.md
+- [ ] Step 1: Load label list from `gh label list`
 - [ ] Step 2: Gather problem description from user
 - [ ] Step 3: Duplicate check (search remote, offer comment / file new / abort)
 - [ ] Step 4: Suggest and confirm labels
@@ -31,38 +31,32 @@ Create todos for each step before starting:
 
 ## Step 1: Load Labels
 
-Read `.github/LABELS.md` from the repository root.
+Fetch the remote label inventory from the current working directory's default
+`gh` repository:
 
-**Parser rules (strict):**
-
-- Locate the `## Labels` heading.
-- Scan forward to the `| Name |` header row of the table.
-- Extract label names from **column 1 only** of every subsequent `|...|` row,
-  until the first line that does not start with `|`. Strip backtick characters
-  from each name.
-- Skip separator rows: any row where column 1 contains only `-` characters
-  and/or whitespace (e.g. `|------|...|`).
-- Ignore all backticks outside this table (Rules Summary, Adding/Changing
-  Labels, When-NOT-to-apply prose, etc. — these reference label names as
-  examples, not as inventory entries).
+```bash
+gh label list --json name,description --jq '.'
+```
 
 **After extraction, assert:**
 
-1. The list is non-empty.
-2. It is alphabetically sorted (A-Z, case-insensitive).
-3. It contains at least `bug` and `enhancement`.
+1. The command exits zero.
+2. The JSON parses successfully.
+3. The list is non-empty.
+4. Every label has a non-empty `name`.
 
 If any assertion fails, halt:
 
-> `.github/LABELS.md table appears malformed — refusing to proceed.`
+> `Could not load remote labels with gh label list — refusing to proceed.`
 
-If the file does not exist, halt:
+Use each label's `description` to guide selection. If one or more labels have
+an empty description, warn but continue:
 
-> `.github/LABELS.md` not found — cannot determine available labels. Ensure the
-> file exists at the repo root before running `/github-flows:new-issue`.
+> `Warning: some remote labels have empty descriptions; label suggestions may be less precise.`
 
-Do NOT hardcode any label names — derive all values from the parsed file every
-run.
+Do NOT hardcode any label names — derive all values from `gh label list` every
+run. A local `.github/LABELS.md` file may exist for repository documentation,
+but it is not required by this workflow and must not block issue creation.
 
 ---
 
@@ -422,7 +416,8 @@ or `github_actions` (e.g., typed it manually), refuse immediately:
 > "`{label}` is a Dependabot-only label — not available via
 > `/github-flows:new-issue`. Pick a different label or proceed with none."
 
-**Remote label existence check:** If any labels were chosen, run:
+**Remote label existence check:** If any labels were chosen, reuse the Step 1
+remote label inventory. If the inventory needs refreshing, run:
 
 ```bash
 gh label list --json name --jq '.[].name'
@@ -431,8 +426,8 @@ gh label list --json name --jq '.[].name'
 Intersect chosen labels against the remote list. If any chosen label is absent
 on remote, refuse:
 
-> "Label `{label}` is in `.github/LABELS.md` but not on the remote repo.
-> Run `gh label create {label} ...` first, or remove it from the selection."
+> "Label `{label}` does not exist on the remote repo. Run
+> `gh label create {label} ...` first, or remove it from the selection."
 
 **Remote milestone existence re-check:** If `$milestone` is non-empty,
 re-validate that it still exists as an open milestone:
@@ -602,9 +597,8 @@ Stop and do NOT call `gh issue create` if:
 5. Any issue number in a relationship does not resolve via GraphQL, or the
    user typed a cross-repo `owner/repo#N` format — emit the refusal from
    Step 6.
-6. `.github/LABELS.md` is missing or malformed — emit the
-   `.github/LABELS.md table appears malformed — refusing to proceed.` halt
-   message from Step 1.
+6. `gh label list` fails, returns malformed JSON, or returns no labels — emit
+   the remote-label halt message from Step 1.
 7. **Public-repo leak guard fired** (Step 7 or Step 8): the draft body
    references a private repository or private-repo-shaped path while the
    target repo visibility is `PUBLIC`. Emit the leak-guard refusal and ask
@@ -618,7 +612,7 @@ Stop and do NOT call `gh issue create` if:
 
 | Step | Action | Blocks on |
 |------|--------|-----------|
-| 1 | Read .github/LABELS.md | File missing or malformed → halt |
+| 1 | Read labels with `gh label list` | Command failure, malformed JSON, or empty list → halt |
 | 2 | Get description | No response → wait |
 | 3 | Duplicate check (gh issue list --search) | Comment / file new / abort prompt; abort stops the workflow |
 | 4 | Suggest + confirm labels | Optional; zero is fine (no labels chosen advisory in Step 9) |
@@ -633,7 +627,7 @@ Stop and do NOT call `gh issue create` if:
 
 | Mistake | Fix |
 |---------|-----|
-| Hardcoding label names | Read from .github/LABELS.md each run |
+| Hardcoding label names | Read from `gh label list` each run |
 | Refusing when no label chosen | Zero labels is valid — print the no-labels-chosen advisory in Step 9 and continue |
 | Using wrong body structure | Match the 5-section template exactly |
 | Creating issues in other repos | Only create in the current repo's default gh target |


### PR DESCRIPTION
# Pull Request

PR title rule for squash merges: use the exact commitlint/commitizen format for the PR title so the squash commit can be reused unchanged.

`type: #123 short description`

Examples:

- `docs: #12 add bootstrap skill guide`
- `chore: #34 bootstrap commit hooks`

This title rule applies to pull requests only. GitHub issue titles should stay plain-language and should not use conventional-commit prefixes.

## Summary

- Updates `/github-flows:new-issue` to load label inventory from `gh label list` instead of requiring `.github/LABELS.md`.
- Aligns issue-filing guidance so local label docs are optional for skills.
- Adds Superteam design and plan artifacts for issue #13.

## Linked issue

- Closes #13

## Acceptance criteria

### AC-13-1

Step 1 now loads labels through `gh label list` and explicitly says local `.github/LABELS.md` must not block issue creation.

- [x] CLI evidence — codex | local | @tlmader | 2026-04-27T04:38:39Z
- [ ] Manual test: 1. In a repo with GitHub labels but no `.github/LABELS.md`, invoke `/github-flows:new-issue`. 2. Confirm Step 1 uses `gh label list` and continues to intent gathering.

### AC-13-2

Pre-creation checks validate selected labels against the remote label list and use a remote-missing refusal.

- [x] CLI evidence — codex | local | @tlmader | 2026-04-27T04:38:39Z
- [ ] Manual test: 1. Select a label that is not present on the remote. 2. Confirm `/github-flows:new-issue` refuses with the remote-repo missing-label message.

### AC-13-3

Issue-filing guidance now points contributors to `gh label list --json name,description` and marks `.github/LABELS.md` as optional for skills.

- [x] CLI evidence — codex | local | @tlmader | 2026-04-27T04:38:39Z
- [ ] Manual test: 1. Read `docs/issue-filing-style.md`. 2. Confirm the Labels section identifies the remote GitHub label inventory and says skills must not require `.github/LABELS.md`.

### AC-13-4

Reviewer pressure-tested the missing `.github/LABELS.md`, chosen-label, and zero-label workflow paths with no blocking findings.

- [x] Reviewer evidence — codex | local | @tlmader | 2026-04-27T04:38:39Z
- [ ] Manual test: 1. Review the PR conversation and changed workflow. 2. Confirm the pressure-test results cover the three issue paths.

## Validation

- `pnpm lint:md`
- `git diff --check origin/main..HEAD`
- `gh label list --json name,description --jq 'length'`
- Stale mandatory `.github/LABELS.md` halt-language search returned no matches

## Docs updated

- [ ] Not needed
- [x] Updated in this PR
