### PR TITLE
feat: #15 add using-github guide

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -30,7 +30,7 @@
     "privacyPolicyURL": "https://github.com/patinaproject/github-flows",
     "termsOfServiceURL": "https://github.com/patinaproject/github-flows",
     "defaultPrompt": [
-      "Use $github-flows for the workflow described in this plugin's README."
+      "Use $github-flows:using-github for the workflow described in this plugin's README."
     ],
     "brandColor": "#E6A77E"
   }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -30,7 +30,7 @@
     "privacyPolicyURL": "https://github.com/patinaproject/github-flows",
     "termsOfServiceURL": "https://github.com/patinaproject/github-flows",
     "defaultPrompt": [
-      "Use $github-flows:using-github for the workflow described in this plugin's README."
+      "Use $using-github for the workflow described in this plugin's README."
     ],
     "brandColor": "#E6A77E"
   }

--- a/.cursor/rules/github-flows.mdc
+++ b/.cursor/rules/github-flows.mdc
@@ -7,6 +7,10 @@ alwaysApply: true
 
 This repository follows the conventions documented in [`AGENTS.md`](/AGENTS.md). Prefer guidance from that file for workflow, commit message, and file-layout rules.
 
+For GitHub work, start from `/github-flows:using-github`. It is the central
+behavior guide and routes task-specific work to `new-issue`, `edit-issue`,
+`new-branch`, and `write-changelog`.
+
 Key rules:
 
 - Commits use Conventional Commits with no scope and a required GitHub issue tag: `type: #123 short description`. Subject ≤ 72 chars.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,10 @@
 
 This repository follows the conventions documented in [`AGENTS.md`](../AGENTS.md). Copilot should prefer guidance from that file for workflow, commit message, and file-layout rules.
 
+For GitHub work, start from `/github-flows:using-github`. It is the central
+behavior guide and routes task-specific work to `new-issue`, `edit-issue`,
+`new-branch`, and `write-changelog`.
+
 Highlights:
 
 - Commits use Conventional Commits with no scope and a required GitHub issue tag: `type: #123 short description`.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -2,6 +2,10 @@
 
 This repository follows the conventions documented in `AGENTS.md`. Prefer guidance from that file for workflow, commit message, and file-layout rules.
 
+For GitHub work, start from `/github-flows:using-github`. It is the central
+behavior guide and routes task-specific work to `new-issue`, `edit-issue`,
+`new-branch`, and `write-changelog`.
+
 Key rules:
 
 - Commits use Conventional Commits with no scope and a required GitHub issue tag: `type: #123 short description`. Subject ≤ 72 chars.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,13 @@ Format acceptance criteria IDs as `AC-<issue-number>-<integer>`, for example `AC
 - `.husky/commit-msg <path>`: run commit-message validation through the active Git hook.
 - `.husky/pre-commit`: run `lint-staged`, which invokes `markdownlint-cli2` on staged `*.md`.
 
+## GitHub Workflow Skill
+
+When GitHub work is requested, start from `/github-flows:using-github`.
+It is the central behavior guide for this repository's GitHub conventions and
+routes task-specific work to `new-issue`, `edit-issue`, `new-branch`, and
+`write-changelog`.
+
 ## Coding Style & Naming Conventions
 
 Use Markdown for skill and docs content. Keep sections short, imperative, and repository-specific.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Slash-command skills that let coding agents file issues, start branches, edit is
 
 ## What you get
 
+- **`/github-flows:using-github`** — Start here for GitHub work. It centers repository conventions and routes agents to the right specialized workflow.
 - **`/github-flows:new-issue`** — File a new GitHub issue with smart label selection, duplicate detection, and a public-repo leak guard.
 - **`/github-flows:edit-issue`** — Edit an existing issue's title, body, labels, assignees, milestone, state, close reason, or relationships, preferring GraphQL where REST falls short.
 - **`/github-flows:new-branch`** — Start work on an issue: branch from the default branch as `<issue-number>-<kebab-title>`, rebase, and install dependencies via the highest-priority lockfile.
@@ -31,13 +32,14 @@ Get from zero to a real invocation in under a minute (assumes [Claude Code](http
    /plugin install github-flows@patinaproject-skills
    ```
 
-3. File a real issue against this repo to confirm everything works:
+3. Invoke the GitHub behavior guide from a target repository:
 
    ```text
-   /github-flows:new-issue patinaproject/github-flows "Tried github-flows quick start"
+   /github-flows:using-github
    ```
 
-The skill drafts the issue, runs duplicate detection, and asks you to confirm before posting.
+The guide points the agent to the correct workflow for filing issues, starting
+branches, editing issues, writing changelogs, and preparing public-safe PRs.
 
 ## Install in another editor
 
@@ -63,7 +65,7 @@ The skill drafts the issue, runs duplicate detection, and asks you to confirm be
 3. Open a target repository (or an issue in one) in Claude Code and invoke:
 
    ```text
-   /github-flows:new-issue patinaproject/github-flows "Tried github-flows install steps"
+   /github-flows:using-github
    ```
 
 ### OpenAI Codex CLI
@@ -79,7 +81,7 @@ The skill drafts the issue, runs duplicate detection, and asks you to confirm be
 3. Invoke from the target repository:
 
    ```text
-   Use $github-flows for the workflow described above.
+   Use $github-flows:using-github for the workflow described above.
    ```
 
 ### OpenAI Codex App
@@ -89,7 +91,7 @@ The skill drafts the issue, runs duplicate detection, and asks you to confirm be
 3. Invoke:
 
    ```text
-   Use $github-flows for the workflow described above.
+   Use $github-flows:using-github for the workflow described above.
    ```
 
 ### GitHub Copilot
@@ -100,7 +102,7 @@ No plugin install required. This repo ships `.github/copilot-instructions.md`, w
 2. Invoke `github-flows` from Copilot Chat:
 
    ```text
-   @workspace Use the github-flows skill for the workflow described above.
+   @workspace Use the github-flows using-github skill for the workflow described above.
    ```
 
 Personal Copilot preferences belong in your user-scoped Copilot settings, not in the emitted `.github/copilot-instructions.md`.
@@ -113,7 +115,7 @@ No plugin install required. This repo ships `.cursor/rules/github-flows.mdc`, wh
 2. Ask the Cursor agent to apply `github-flows`:
 
    ```text
-   Use the github-flows skill for the workflow described above.
+   Use the github-flows using-github skill for the workflow described above.
    ```
 
 Personal Cursor rules belong in your user-scoped Cursor settings, not in the emitted `.cursor/rules/`.
@@ -126,7 +128,7 @@ No plugin install required. This repo ships `.windsurfrules`, which Windsurf rea
 2. Ask Cascade to apply `github-flows`:
 
    ```text
-   Use the github-flows skill for the workflow described above.
+   Use the github-flows using-github skill for the workflow described above.
    ```
 
 ### Aider
@@ -134,28 +136,28 @@ No plugin install required. This repo ships `.windsurfrules`, which Windsurf rea
 No plugin install required. Aider reads `AGENTS.md` natively.
 
 1. Clone the repo.
-2. Run `aider` from inside the repo and ask it to apply the `github-flows` workflow described in `AGENTS.md`.
+2. Run `aider` from inside the repo and ask it to apply the `github-flows` `using-github` workflow described in `AGENTS.md`.
 
 ### Zed
 
 No plugin install required. Zed's assistant reads `AGENTS.md` natively.
 
 1. Clone the repo and open it in Zed.
-2. Ask the assistant to apply the `github-flows` workflow described in `AGENTS.md`.
+2. Ask the assistant to apply the `github-flows` `using-github` workflow described in `AGENTS.md`.
 
 ### Cline
 
 No plugin install required. Cline reads `AGENTS.md` natively when the repo is open in VS Code.
 
 1. Clone the repo and open it in VS Code with the Cline extension active.
-2. Ask Cline to apply the `github-flows` workflow described in `AGENTS.md`.
+2. Ask Cline to apply the `github-flows` `using-github` workflow described in `AGENTS.md`.
 
 ### Opencode
 
 No plugin install required. Opencode reads `AGENTS.md` natively.
 
 1. Clone the repo and open it in Opencode.
-2. Ask Opencode to apply the `github-flows` workflow described in `AGENTS.md`.
+2. Ask Opencode to apply the `github-flows` `using-github` workflow described in `AGENTS.md`.
 
 ### Continue.dev
 
@@ -174,7 +176,7 @@ Continue.dev support is opt-in. Add the following entry to your `.continue/confi
 }
 ```
 
-Then ask Continue to apply the `github-flows` workflow described in `AGENTS.md`.
+Then ask Continue to apply the `github-flows` `using-github` workflow described in `AGENTS.md`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ branches, editing issues, writing changelogs, and preparing public-safe PRs.
 3. Invoke from the target repository:
 
    ```text
-   Use $github-flows:using-github for the workflow described above.
+   Use $using-github for the workflow described above.
    ```
 
 ### OpenAI Codex App
@@ -91,7 +91,7 @@ branches, editing issues, writing changelogs, and preparing public-safe PRs.
 3. Invoke:
 
    ```text
-   Use $github-flows:using-github for the workflow described above.
+   Use $using-github for the workflow described above.
    ```
 
 ### GitHub Copilot

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -15,6 +15,9 @@ Contributor reference for the repository layout. For user-facing install and usa
 ## Skills
 
 Each skill lives in its own directory under `skills/` with `SKILL.md` as the main contract.
+`skills/using-github/` is the umbrella GitHub behavior skill. The other skill
+directories are specialized workflows that it routes to for issue filing,
+issue editing, branch setup, and changelog writing.
 
 ## Docs
 

--- a/docs/issue-filing-style.md
+++ b/docs/issue-filing-style.md
@@ -1,6 +1,6 @@
 # Issue filing style
 
-This is the canonical guide for filing GitHub issues in `patinaproject/github-flows`. The `/github-flows:new-issue` skill reads this document at runtime and uses it as the single source of truth for body shape, AC format, label/milestone/relationship conventions, and the public-repo leak guard. Contributors filing issues by hand should follow the same rules.
+This is the canonical guide for filing GitHub issues in `patinaproject/github-flows`. For general GitHub work, start from `/github-flows:using-github`; it routes issue filing to `/github-flows:new-issue`. The `/github-flows:new-issue` skill reads this document at runtime and uses it as the single source of truth for body shape, AC format, label/milestone/relationship conventions, and the public-repo leak guard. Contributors filing issues by hand should follow the same rules.
 
 For the label inventory, run `gh label list --json name,description`.
 
@@ -115,5 +115,6 @@ Contributors filing issues by hand should apply the same standard. If a discussi
 
 ## Reference implementations
 
+- [`skills/using-github/SKILL.md`](../skills/using-github/SKILL.md) — the agent-facing entry point for GitHub behavior.
 - [`skills/new-issue/SKILL.md`](../skills/new-issue/SKILL.md) — the agent-facing skill that automates issue filing per this guide.
 - `patinaproject/patinaproject` `.claude/skills/new-issue/workflow.md` — the upstream reference this skill is derived from.

--- a/docs/superpowers/plans/2026-04-27-15-introduce-using-github-as-the-central-github-behavior-guide-plan.md
+++ b/docs/superpowers/plans/2026-04-27-15-introduce-using-github-as-the-central-github-behavior-guide-plan.md
@@ -1,0 +1,273 @@
+# Introduce /using-github as the central GitHub behavior guide Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `/using-github` as the umbrella GitHub behavior skill and center repository guidance around it.
+
+**Architecture:** Keep existing workflow skills authoritative and add a small routing skill at `skills/using-github/SKILL.md`. Update user-facing and editor guidance to point agents to `/using-github` first, while preserving detailed procedures in the current specialized skills. Record RED/GREEN pressure-test evidence as durable documentation.
+
+**Tech Stack:** Markdown skills and docs, GitHub CLI conventions, `markdownlint-cli2`, `rg`, Git.
+
+---
+
+## File Structure
+
+- Create `skills/using-github/SKILL.md`: umbrella skill contract and routing guide.
+- Create `docs/superpowers/pressure-tests/2026-04-27-15-using-github-pressure-test.md`: RED/GREEN pressure-test evidence for the new skill.
+- Modify `README.md`: introduce `/using-github` first and update quick-start invocation.
+- Modify `AGENTS.md`: point GitHub work toward `/using-github`.
+- Modify `.github/copilot-instructions.md`: center Copilot guidance on `/using-github`.
+- Modify `.cursor/rules/github-flows.mdc`: center Cursor guidance on `/using-github`.
+- Modify `.windsurfrules`: center Windsurf guidance on `/using-github`.
+- Modify `docs/file-structure.md`: include `using-github` in the skill inventory.
+
+## Task 1: RED Pressure Scenario
+
+**Files:**
+
+- Create: `docs/superpowers/pressure-tests/2026-04-27-15-using-github-pressure-test.md`
+
+- [ ] **Step 1: Run the baseline pressure scenario**
+
+Dispatch or simulate a fresh-agent prompt without mentioning `/using-github`:
+
+```text
+You are in patinaproject/github-flows. A user asks you to file a GitHub issue,
+start an issue branch, update PR guidance, and avoid leaking private repo
+details. Which repository guidance and skills do you use first?
+```
+
+Expected RED evidence: the agent may find individual skills or docs, but there
+is no single umbrella skill to invoke as the central GitHub behavior guide.
+
+- [ ] **Step 2: Record the RED result**
+
+Create the pressure-test document:
+
+```markdown
+# Pressure Test: /using-github Skill [#15](https://github.com/patinaproject/github-flows/issues/15)
+
+## RED: Baseline Without /using-github
+
+Prompt:
+
+> You are in patinaproject/github-flows. A user asks you to file a GitHub issue,
+> start an issue branch, update PR guidance, and avoid leaking private repo
+> details. Which repository guidance and skills do you use first?
+
+Observed gap:
+
+- No `skills/using-github/SKILL.md` exists.
+- Agents must discover `new-issue`, `new-branch`, `edit-issue`,
+  `write-changelog`, `AGENTS.md`, and issue-filing docs piecemeal.
+- There is no central skill that tells agents how to route mixed GitHub work.
+
+Expected fix:
+
+- `/using-github` exists and routes mixed GitHub work through the current
+  specialized skills and repository docs.
+
+## GREEN: With /using-github
+
+This section is completed after the skill and docs are implemented so RED
+evidence is committed before GREEN evidence.
+```
+
+- [ ] **Step 3: Commit RED evidence**
+
+```bash
+git add docs/superpowers/pressure-tests/2026-04-27-15-using-github-pressure-test.md
+git commit -m "test: #15 capture using-github pressure scenario"
+```
+
+## Task 2: Add the /using-github Skill
+
+**Files:**
+
+- Create: `skills/using-github/SKILL.md`
+
+- [ ] **Step 1: Write the skill**
+
+Create `skills/using-github/SKILL.md`:
+
+```markdown
+---
+name: using-github
+description: Use when an agent is asked to perform GitHub work in a repository that should follow github-flows conventions
+---
+
+# Using GitHub
+
+Use this skill as the entry point for GitHub work. It orients the agent to the
+repository's GitHub rules, then routes task-specific work to the specialized
+github-flows skills.
+
+## First Checks
+
+- Read root repository guidance such as `AGENTS.md`.
+- Read local docs that govern the files or GitHub surface being changed.
+- Use repository templates for issues and pull requests.
+- Use canonical labels from the repository label inventory.
+- Do not manually apply or remove reserved release automation labels.
+- Keep public-repo output free of private repository URLs, private paths, and
+  private content.
+
+## Route Work
+
+- New issue: use `/github-flows:new-issue`.
+- Existing issue edit: use `/github-flows:edit-issue`.
+- Start issue work: use `/github-flows:new-branch`.
+- Milestone changelog: use `/github-flows:write-changelog`.
+- Pull request: read `.github/pull_request_template.md`, use the repo's PR
+  title format, and include acceptance-criteria verification when the issue
+  defines acceptance criteria.
+
+## Shared GitHub Rules
+
+- Branches for issue work use `<issue-number>-<kebab-title>` from the default
+  branch.
+- Commits and squash PR titles use `type: #123 short description` with no
+  scope.
+- GitHub issue titles are plain-language summaries, not conventional commits.
+- Relationships are same-repo `#N` references unless repository guidance says
+  otherwise.
+- Public issue, PR, and changelog text must pass the public-repo leak guard.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Copying detailed steps from another skill into this one | Keep this skill as a router and use the specialized skill for the procedure. |
+| Inventing labels or templates | Read the repository label inventory and templates. |
+| Treating PR creation as just a `gh pr create` command | Satisfy the repository PR template, title format, and acceptance-criteria rules first. |
+| Including private repository context in public text | Rewrite as a public-safe summary or file in a private repository first. |
+```
+
+- [ ] **Step 2: Verify the skill is concise and discoverable**
+
+Run:
+
+```bash
+sed -n '1,220p' skills/using-github/SKILL.md
+```
+
+Expected: frontmatter description describes when to use the skill and the body
+routes to current specialized workflows without copying their full procedures.
+
+## Task 3: Center User and Agent Guidance
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `.github/copilot-instructions.md`
+- Modify: `.cursor/rules/github-flows.mdc`
+- Modify: `.windsurfrules`
+- Modify: `docs/file-structure.md`
+
+- [ ] **Step 1: Update README**
+
+Update "What you get" so `/github-flows:using-github` appears first as the
+entry-point skill. Keep the four specialized skills listed as routed workflows.
+Update quick-start examples to invoke `/github-flows:using-github` for general
+GitHub work.
+
+- [ ] **Step 2: Update repository guidance**
+
+Add concise guidance to `AGENTS.md`:
+
+```markdown
+## GitHub workflow skill
+
+When GitHub work is requested, start from `/github-flows:using-github`.
+It is the central behavior guide for this repository's GitHub conventions and
+routes task-specific work to `new-issue`, `edit-issue`, `new-branch`, and
+`write-changelog`.
+```
+
+- [ ] **Step 3: Update editor guidance surfaces**
+
+Add matching short guidance to `.github/copilot-instructions.md`,
+`.cursor/rules/github-flows.mdc`, and `.windsurfrules` so each tells the agent
+to start GitHub work from `/github-flows:using-github`.
+
+- [ ] **Step 4: Update file-structure docs**
+
+In `docs/file-structure.md`, mention that `skills/using-github/` is the
+umbrella GitHub behavior skill and the other skill directories are specialized
+workflows.
+
+## Task 4: GREEN Pressure Scenario and Verification
+
+**Files:**
+
+- Modify: `docs/superpowers/pressure-tests/2026-04-27-15-using-github-pressure-test.md`
+
+- [ ] **Step 1: Run the matching GREEN pressure scenario**
+
+Dispatch or simulate a fresh-agent prompt that explicitly has `/using-github`
+available:
+
+```text
+Use /github-flows:using-github for mixed GitHub work in this repository. A user
+asks you to file a GitHub issue, start an issue branch, update PR guidance, and
+avoid leaking private repo details. Which repository guidance and skills do you
+use first?
+```
+
+Expected GREEN evidence: the agent starts from `/using-github`, reads repo
+guidance, and routes to `new-issue`, `new-branch`, PR template rules, and the
+public-repo leak guard instead of inventing a parallel process.
+
+- [ ] **Step 2: Record the GREEN result**
+
+Replace the pending GREEN section with:
+
+```markdown
+## GREEN: With /using-github
+
+Prompt:
+
+> Use /github-flows:using-github for mixed GitHub work in this repository. A
+> user asks you to file a GitHub issue, start an issue branch, update PR
+> guidance, and avoid leaking private repo details. Which repository guidance
+> and skills do you use first?
+
+Observed pass:
+
+- `/using-github` is the first skill for mixed GitHub behavior.
+- New issues route to `/github-flows:new-issue`.
+- Issue branches route to `/github-flows:new-branch`.
+- PR work routes through `.github/pull_request_template.md`, commit and PR
+  title rules, and acceptance-criteria verification.
+- Public text is checked against public-repo leak-guard expectations.
+- The umbrella skill does not duplicate the detailed specialized workflows.
+```
+
+- [ ] **Step 3: Run repository verification**
+
+```bash
+pnpm lint:md
+rg -n "using-github|new-issue|new-branch|edit-issue|write-changelog" README.md AGENTS.md .github/copilot-instructions.md .cursor/rules/github-flows.mdc .windsurfrules docs/file-structure.md skills/using-github/SKILL.md docs/superpowers/pressure-tests/2026-04-27-15-using-github-pressure-test.md
+sed -n '1,220p' skills/using-github/SKILL.md
+```
+
+Expected: Markdown lint passes, references show `/using-github` centered while
+specialized workflows remain linked, and the skill has no placeholders.
+
+- [ ] **Step 4: Commit implementation**
+
+```bash
+git add README.md AGENTS.md .github/copilot-instructions.md .cursor/rules/github-flows.mdc .windsurfrules docs/file-structure.md skills/using-github/SKILL.md docs/superpowers/pressure-tests/2026-04-27-15-using-github-pressure-test.md
+git commit -m "feat: #15 add using-github guide"
+```
+
+## Self-Review
+
+- Spec coverage: Task 2 implements `AC-15-1`; Task 2 and Task 4 implement
+  `AC-15-2`; Task 3 implements `AC-15-3`; Task 1 and Task 4 implement the
+  `writing-skills` pressure-test requirement.
+- Placeholder scan: no placeholder steps are intentionally left for Executor.
+- Type consistency: this is Markdown-only work; paths and skill names use
+  `using-github`, `new-issue`, `edit-issue`, `new-branch`, and
+  `write-changelog` consistently.

--- a/docs/superpowers/pressure-tests/2026-04-27-15-using-github-pressure-test.md
+++ b/docs/superpowers/pressure-tests/2026-04-27-15-using-github-pressure-test.md
@@ -24,5 +24,28 @@ Expected fix:
 
 ## GREEN: With /using-github
 
-This section is completed after the skill and docs are implemented so RED
-evidence is committed before GREEN evidence.
+Prompt:
+
+> Use /github-flows:using-github for mixed GitHub work in this repository. A
+> user asks you to file a GitHub issue, start an issue branch, update PR
+> guidance, and avoid leaking private repo details. Which repository guidance
+> and skills do you use first?
+
+Observed pass:
+
+- `/github-flows:using-github` is the first skill for mixed GitHub behavior.
+- New issues route to `/github-flows:new-issue`.
+- Issue branches route to `/github-flows:new-branch`.
+- Existing issue edits route to `/github-flows:edit-issue`.
+- Milestone changelogs route to `/github-flows:write-changelog`.
+- PR work routes through `.github/pull_request_template.md`, commit and PR
+  title rules, and acceptance-criteria verification.
+- Public text is checked against public-repo leak-guard expectations from the
+  repository docs.
+- The umbrella skill does not duplicate the detailed specialized workflows.
+
+Non-blocking note:
+
+- There is no dedicated PR skill. `/using-github` correctly routes PR work to
+  repository guidance and the PR template instead of inventing another
+  workflow.

--- a/docs/superpowers/pressure-tests/2026-04-27-15-using-github-pressure-test.md
+++ b/docs/superpowers/pressure-tests/2026-04-27-15-using-github-pressure-test.md
@@ -17,6 +17,16 @@ Observed gap:
   `docs/issue-filing-style.md`, and the individual skill contracts piecemeal.
 - There is no central skill that tells agents how to route mixed GitHub work.
 
+Observed baseline response:
+
+- The baseline agent found only `skills/new-issue/SKILL.md`,
+  `skills/new-branch/SKILL.md`, `skills/edit-issue/SKILL.md`, and
+  `skills/write-changelog/SKILL.md`.
+- It said it would start with `AGENTS.md`, then separately inspect
+  `new-issue`, `new-branch`, `docs/issue-filing-style.md`, and the PR template.
+- It identified the gap as "the repo has the ingredients, but not the
+  entrypoint."
+
 Expected fix:
 
 - `/using-github` exists and routes mixed GitHub work through the current
@@ -26,12 +36,11 @@ Expected fix:
 
 Prompt:
 
-> Use /github-flows:using-github for mixed GitHub work in this repository. A
-> user asks you to file a GitHub issue, start an issue branch, update PR
-> guidance, and avoid leaking private repo details. Which repository guidance
-> and skills do you use first?
+> You are in patinaproject/github-flows. A user asks you to file a GitHub issue,
+> start an issue branch, update PR guidance, and avoid leaking private repo
+> details. Which repository guidance and skills do you use first?
 
-Observed pass:
+Observed fresh-agent response:
 
 - `/github-flows:using-github` is the first skill for mixed GitHub behavior.
 - New issues route to `/github-flows:new-issue`.
@@ -43,9 +52,13 @@ Observed pass:
 - Public text is checked against public-repo leak-guard expectations from the
   repository docs.
 - The umbrella skill does not duplicate the detailed specialized workflows.
+- No conflicting duplicate mixed-GitHub procedure was found.
 
 Non-blocking note:
 
 - There is no dedicated PR skill. `/using-github` correctly routes PR work to
   repository guidance and the PR template instead of inventing another
   workflow.
+- Codex-facing prompts use the `$using-github` shorthand while most repository
+  docs use `/github-flows:using-github`; this is editor-specific invocation
+  syntax, not a procedural conflict.

--- a/docs/superpowers/pressure-tests/2026-04-27-15-using-github-pressure-test.md
+++ b/docs/superpowers/pressure-tests/2026-04-27-15-using-github-pressure-test.md
@@ -1,0 +1,28 @@
+# Pressure Test: /using-github Skill [#15](https://github.com/patinaproject/github-flows/issues/15)
+
+## RED: Baseline Without /using-github
+
+Prompt:
+
+> You are in patinaproject/github-flows. A user asks you to file a GitHub issue,
+> start an issue branch, update PR guidance, and avoid leaking private repo
+> details. Which repository guidance and skills do you use first?
+
+Observed gap:
+
+- No `skills/using-github/SKILL.md` exists.
+- The available skill entry points are `new-issue`, `new-branch`,
+  `edit-issue`, and `write-changelog`.
+- Agents must discover `AGENTS.md`, `.github/pull_request_template.md`,
+  `docs/issue-filing-style.md`, and the individual skill contracts piecemeal.
+- There is no central skill that tells agents how to route mixed GitHub work.
+
+Expected fix:
+
+- `/using-github` exists and routes mixed GitHub work through the current
+  specialized skills and repository docs.
+
+## GREEN: With /using-github
+
+This section is completed after the skill and docs are implemented so RED
+evidence is committed before GREEN evidence.

--- a/docs/superpowers/pressure-tests/2026-04-27-15-using-github-pressure-test.md
+++ b/docs/superpowers/pressure-tests/2026-04-27-15-using-github-pressure-test.md
@@ -2,6 +2,14 @@
 
 ## RED: Baseline Without /using-github
 
+Run metadata:
+
+- Agent: `019dcd76-3d05-7ab1-9958-befe174efb14` (`Noether`)
+- Workspace: `/Users/tlmader/.codex/worktrees/9d37/github-flows`
+- Commit under test: `c1ce4aa` (`docs: #15 plan using-github implementation`)
+- Context: design and implementation plan existed; `skills/using-github/` did
+  not exist.
+
 Prompt:
 
 > You are in patinaproject/github-flows. A user asks you to file a GitHub issue,
@@ -27,12 +35,29 @@ Observed baseline response:
 - It identified the gap as "the repo has the ingredients, but not the
   entrypoint."
 
+Transcript excerpt:
+
+- "There is no single umbrella skill currently available to invoke for the
+  mixed prompt."
+- "So from a fresh-agent perspective, I would have to assemble the answer
+  piecemeal."
+- "The repo has the ingredients, but not the entrypoint."
+
 Expected fix:
 
 - `/using-github` exists and routes mixed GitHub work through the current
   specialized skills and repository docs.
 
 ## GREEN: With /using-github
+
+Run metadata:
+
+- Agent: `019dcd7d-7e44-72b3-8665-f1defad4c26c` (`Bacon`)
+- Workspace: `/Users/tlmader/.codex/worktrees/9d37/github-flows`
+- Commit under test: working tree later committed as `0dc30e1`
+  (`fix: #15 align using-github prompts`)
+- Context: `skills/using-github/SKILL.md`, OpenAI skill metadata, repository
+  guidance updates, and Codex `$using-github` prompt alignment were present.
 
 Prompt:
 
@@ -62,3 +87,13 @@ Non-blocking note:
 - Codex-facing prompts use the `$using-github` shorthand while most repository
   docs use `/github-flows:using-github`; this is editor-specific invocation
   syntax, not a procedural conflict.
+
+Transcript excerpt:
+
+- "Yes: current repo guidance discovers `/github-flows:using-github` as the
+  central entry point."
+- "`skills/using-github/SKILL.md` routes: new issues to
+  `/github-flows:new-issue`, existing issue edits to
+  `/github-flows:edit-issue`, issue branches to `/github-flows:new-branch`,
+  milestone changelogs to `/github-flows:write-changelog`."
+- "I did not find a conflicting duplicate mixed-GitHub procedure."

--- a/docs/superpowers/specs/2026-04-27-15-introduce-using-github-as-the-central-github-behavior-guide-design.md
+++ b/docs/superpowers/specs/2026-04-27-15-introduce-using-github-as-the-central-github-behavior-guide-design.md
@@ -22,6 +22,9 @@ task calls for issue filing, branch setup, issue editing, or changelog writing.
   reservations.
 - Update user-facing docs and editor guidance so they center GitHub work around
   `/using-github`.
+- Use `superpowers:writing-skills` discipline for the new skill: capture a
+  baseline pressure scenario before the skill exists, then verify the written
+  skill closes the observed behavior gap.
 - Keep instructions concise, imperative, and compatible with Markdown linting.
 
 ## Approaches Considered
@@ -55,8 +58,9 @@ portable skill contract to invoke across runtimes.
 ## Design
 
 Add `skills/using-github/SKILL.md` with frontmatter that describes the skill as
-the behavior guide for GitHub work in repositories that use this plugin. Its
-body should tell agents to:
+the behavior guide for GitHub work in repositories that use this plugin.
+Following `superpowers:writing-skills`, the description should describe when to
+use the skill, not summarize the workflow. Its body should tell agents to:
 
 - discover repository guidance before acting;
 - use `/github-flows:new-issue` for new issues;
@@ -96,6 +100,13 @@ should mention the new skill directory as part of the skill inventory.
 
 ## Testing
 
+- Before writing the final skill text, run or document a RED pressure scenario
+  showing the current behavior without `/using-github`. The scenario should ask
+  an agent to handle a mixed GitHub task and record whether it discovers the
+  specialized workflows and shared repository rules without the umbrella skill.
+- After writing the skill, run or document the matching GREEN pressure scenario
+  showing that `/using-github` routes the agent to existing workflows and shared
+  GitHub conventions without copying conflicting procedure.
 - Run `pnpm lint:md`.
 - Use `rg "using-github|new-issue|new-branch|edit-issue|write-changelog"` to
   confirm the new skill and docs route to the expected workflows.
@@ -113,4 +124,6 @@ should mention the new skill directory as part of the skill inventory.
 
 No approval-relevant concerns remain. The main implementation risk is drift:
 `/using-github` must stay concise and route to the existing workflow files
-instead of copying their steps.
+instead of copying their steps. The implementation plan must include the
+`writing-skills` pressure-test loop so the skill is verified as process
+documentation, not only linted as Markdown.

--- a/docs/superpowers/specs/2026-04-27-15-introduce-using-github-as-the-central-github-behavior-guide-design.md
+++ b/docs/superpowers/specs/2026-04-27-15-introduce-using-github-as-the-central-github-behavior-guide-design.md
@@ -1,0 +1,116 @@
+# Design: Introduce /using-github as the central GitHub behavior guide [#15](https://github.com/patinaproject/github-flows/issues/15)
+
+## Intent
+
+Introduce `/using-github` as the entry-point skill for GitHub behavior in this
+repository. The new skill should orient agents to the repository's GitHub
+operating rules and then route them to the existing specialized skills when a
+task calls for issue filing, branch setup, issue editing, or changelog writing.
+
+## Requirements
+
+- Create a self-contained `skills/using-github/` skill with `SKILL.md` as the
+  main contract.
+- Make `/using-github` the starting point for repository-specific GitHub
+  behavior, not a replacement for the existing workflow skills.
+- Direct agents from `/using-github` to the current specialized skills for
+  filing issues, editing issues, creating issue branches, and writing
+  changelogs.
+- Include the GitHub conventions that apply across workflows: canonical labels,
+  issue and PR templates, same-repo relationship rules, public-repo leak
+  safety, branch naming, commit title format, PR title format, and release-label
+  reservations.
+- Update user-facing docs and editor guidance so they center GitHub work around
+  `/using-github`.
+- Keep instructions concise, imperative, and compatible with Markdown linting.
+
+## Approaches Considered
+
+### Recommended: Umbrella Skill With Routed Workflows
+
+Add `skills/using-github/SKILL.md` as an umbrella behavior guide. The skill owns
+the cross-cutting GitHub posture and points to the existing workflow skills for
+task-specific procedures.
+
+This keeps the current skills authoritative, avoids duplicating long procedural
+steps, and gives agents one obvious starting point when the user asks for
+GitHub work.
+
+### Alternative: Merge Existing Skills Into One Large Skill
+
+The repository could collapse all GitHub flows into `/using-github`.
+
+This would create a single command, but it would also make the skill harder to
+review, harder to test, and more likely to drift from the individual workflows
+that already work.
+
+### Alternative: Documentation-Only Reorientation
+
+The repository could update `README.md`, `AGENTS.md`, and editor guidance to
+mention `/using-github` without adding a real skill.
+
+This would improve discoverability slightly, but agents would still lack a
+portable skill contract to invoke across runtimes.
+
+## Design
+
+Add `skills/using-github/SKILL.md` with frontmatter that describes the skill as
+the behavior guide for GitHub work in repositories that use this plugin. Its
+body should tell agents to:
+
+- discover repository guidance before acting;
+- use `/github-flows:new-issue` for new issues;
+- use `/github-flows:edit-issue` for issue metadata or body edits;
+- use `/github-flows:new-branch` when starting work from an issue;
+- use `/github-flows:write-changelog` for milestone changelogs;
+- follow canonical labels, templates, relationship, public-safety, commit, and
+  PR-title rules from repository docs;
+- avoid mutating reserved release labels manually.
+
+The skill should be an orienting contract, not a procedural clone. It should
+name the current source documents and specialized skills, then defer to them
+for detailed steps.
+
+Update `README.md` so the "What you get" and quick-start guidance introduce
+`/using-github` first. The specialized skills should remain visible as routed
+workflows available through the umbrella behavior.
+
+Update repository guidance surfaces that teach agents how to behave in this
+repo. At minimum, `AGENTS.md`, `.github/copilot-instructions.md`,
+`.cursor/rules/github-flows.mdc`, and `.windsurfrules` should point GitHub work
+toward `/using-github` before listing individual conventions. `docs/file-structure.md`
+should mention the new skill directory as part of the skill inventory.
+
+## Acceptance Criteria
+
+- AC-15-1: Given an agent is asked to perform GitHub work in this repository,
+  when the `/using-github` skill is available, then the agent can use it as the
+  central behavior guide for repository-specific GitHub conventions.
+- AC-15-2: Given the repository's existing GitHub-flow skills remain in place,
+  when `/using-github` references issue, branch, PR, changelog, label, template,
+  or public-safety behavior, then it directs agents to the current prescribed
+  workflows instead of duplicating conflicting instructions.
+- AC-15-3: Given contributor-facing docs describe GitHub work, when they are
+  updated, then they center the guidance around `/using-github` as the starting
+  point for agent behavior.
+
+## Testing
+
+- Run `pnpm lint:md`.
+- Use `rg "using-github|new-issue|new-branch|edit-issue|write-changelog"` to
+  confirm the new skill and docs route to the expected workflows.
+- Review `skills/using-github/SKILL.md` directly for contradictions,
+  placeholders, and accidental duplication of detailed workflow steps.
+
+## Out of Scope
+
+- Rewriting the behavior of `new-issue`, `edit-issue`, `new-branch`, or
+  `write-changelog`.
+- Adding new GitHub API behavior.
+- Changing release automation or label inventory.
+
+## Concerns
+
+No approval-relevant concerns remain. The main implementation risk is drift:
+`/using-github` must stay concise and route to the existing workflow files
+instead of copying their steps.

--- a/skills/using-github/SKILL.md
+++ b/skills/using-github/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: using-github
+description: Use when an agent is asked to perform GitHub work in a repository that should follow github-flows conventions
+---
+
+# Using GitHub
+
+Use this skill as the entry point for GitHub work. It orients the agent to the
+repository's GitHub rules, then routes task-specific work to the specialized
+github-flows skills.
+
+## First Checks
+
+- Read root repository guidance such as `AGENTS.md`.
+- Read local docs that govern the files or GitHub surface being changed.
+- Use repository templates for issues and pull requests.
+- Use canonical labels from the repository label inventory.
+- Do not manually apply or remove reserved release automation labels.
+- Keep public-repo output free of private repository URLs, private paths, and
+  private content.
+
+## Route Work
+
+- New issue: use `/github-flows:new-issue`.
+- Existing issue edit: use `/github-flows:edit-issue`.
+- Start issue work: use `/github-flows:new-branch`.
+- Milestone changelog: use `/github-flows:write-changelog`.
+- Pull request: read `.github/pull_request_template.md`, use the repo's PR
+  title format, and include acceptance-criteria verification when the issue
+  defines acceptance criteria.
+
+## Shared GitHub Rules
+
+- Branches for issue work use `<issue-number>-<kebab-title>` from the default
+  branch.
+- Commits and squash PR titles use `type: #123 short description` with no
+  scope.
+- GitHub issue titles are plain-language summaries, not conventional commits.
+- Relationships are same-repo `#N` references unless repository guidance says
+  otherwise.
+- Public issue, PR, and changelog text must pass the public-repo leak guard.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Copying detailed steps from another skill into this one | Keep this skill as a router and use the specialized skill for the procedure. |
+| Inventing labels or templates | Read the repository label inventory and templates. |
+| Treating PR creation as just a `gh pr create` command | Satisfy the repository PR template, title format, and acceptance-criteria rules first. |
+| Including private repository context in public text | Rewrite as a public-safe summary or file in a private repository first. |

--- a/skills/using-github/agents/openai.yaml
+++ b/skills/using-github/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Using GitHub"
+  short_description: "Start GitHub work with repository conventions"
+  default_prompt: "Use $using-github to route GitHub work through the repository's labels, templates, branch, PR, and public-safety conventions."


### PR DESCRIPTION
## Summary

- Adds `/github-flows:using-github` as the central GitHub behavior guide and OpenAI skill entry point.
- Updates README, agent/editor guidance, plugin prompt defaults, and issue docs to route GitHub work through `using-github` first.
- Records auditable RED/GREEN pressure-test evidence for the new skill.

## Linked issue

- Closes #15

## Acceptance criteria

### AC-15-1

`/github-flows:using-github` is available as the central behavior guide for repository-specific GitHub conventions.

- [x] Markdown lint — Codex CLI | local pnpm | @openai-codex | 2026-04-27T05:55:57Z
- [x] Version check — Codex CLI | local pnpm | @openai-codex | 2026-04-27T05:55:57Z
- [ ] Manual test: 1. Install or load the plugin. 2. Invoke `/github-flows:using-github`. 3. Confirm the agent starts from the central GitHub behavior guide.

### AC-15-2

The new guide routes issue, branch, changelog, PR, label, template, and public-safety behavior to existing workflows and repository docs without duplicating conflicting procedures.

- [x] Reference search — Codex CLI | local rg | @openai-codex | 2026-04-27T05:55:57Z
- [x] Pressure test — Codex subagents | local superteam | @openai-codex | 2026-04-27T05:55:57Z
- [ ] Manual test: 1. Ask for mixed GitHub work. 2. Confirm the agent routes new issues, issue branches, issue edits, changelogs, PR guidance, and public-safety checks through the documented paths.

### AC-15-3

Contributor-facing docs and editor guidance now center GitHub work around `/github-flows:using-github` as the starting point.

- [x] Reference search — Codex CLI | local rg | @openai-codex | 2026-04-27T05:55:57Z
- [x] Markdown lint — Codex CLI | local pnpm | @openai-codex | 2026-04-27T05:55:57Z
- [ ] Manual test: 1. Review README, AGENTS.md, Copilot, Cursor, Windsurf, and issue-filing guidance. 2. Confirm each points GitHub work to `using-github` first.

## Validation

- `pnpm lint:md`
- `pnpm check:versions`
- `rg -n '\$github-flows:using-github|\$using-github|/github-flows:using-github' README.md .codex-plugin/plugin.json skills/using-github/agents/openai.yaml docs/superpowers/pressure-tests/2026-04-27-15-using-github-pressure-test.md`
- Local Reviewer re-check: no findings; pressure-test evidence passed on latest head.

## Docs updated

- [x] Updated in this PR
