### PR TITLE
docs: #18 simplify README skill examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,18 @@ Slash-command skills that let coding agents file issues, start branches, edit is
 
 ## What you get
 
-- **`/github-flows:using-github`** — Start here for GitHub work. It centers repository conventions and routes agents to the right specialized workflow.
-- **`/github-flows:new-issue`** — File a new GitHub issue with smart label selection, duplicate detection, and a public-repo leak guard.
-- **`/github-flows:edit-issue`** — Edit an existing issue's title, body, labels, assignees, milestone, state, close reason, or relationships, preferring GraphQL where REST falls short.
-- **`/github-flows:new-branch`** — Start work on an issue: branch from the default branch as `<issue-number>-<kebab-title>`, rebase, and install dependencies via the highest-priority lockfile.
-- **`/github-flows:write-changelog`** — Render a user-facing changelog from a GitHub milestone, sourced from closed issues and their merging PRs.
+- **`/using-github`** — Start here for GitHub work. It reads repository rules
+  and routes issue, branch, PR, and changelog tasks to the right workflow.
+- **`/new-issue`** — File a new GitHub issue with smart label selection,
+  duplicate detection, and a public-repo leak guard.
+- **`/edit-issue`** — Edit an existing issue's title, body, labels, assignees,
+  milestone, state, close reason, or relationships, preferring GraphQL where
+  REST falls short.
+- **`/new-branch`** — Start work on an issue: branch from the default branch as
+  `<issue-number>-<kebab-title>`, rebase, and install dependencies via the
+  highest-priority lockfile.
+- **`/write-changelog`** — Render a user-facing changelog from a GitHub
+  milestone, sourced from closed issues and their merging PRs.
 
 ## Quick start
 
@@ -35,7 +42,10 @@ Get from zero to a real invocation in under a minute (assumes [Claude Code](http
 3. Invoke the GitHub behavior guide from a target repository:
 
    ```text
-   /github-flows:using-github
+   /using-github
+
+   New issue: tried the github-flows quick start. When the issue is created,
+   start a branch for it.
    ```
 
 The guide points the agent to the correct workflow for filing issues, starting
@@ -65,7 +75,10 @@ branches, editing issues, writing changelogs, and preparing public-safe PRs.
 3. Open a target repository (or an issue in one) in Claude Code and invoke:
 
    ```text
-   /github-flows:using-github
+   /using-github
+
+   New issue: tried the github-flows install steps. When the issue is created,
+   start a branch for it.
    ```
 
 ### OpenAI Codex CLI
@@ -81,7 +94,10 @@ branches, editing issues, writing changelogs, and preparing public-safe PRs.
 3. Invoke from the target repository:
 
    ```text
-   Use $using-github for the workflow described above.
+   [$github-flows:using-github]
+
+   New issue: simplify the README examples. When the issue is created, create a
+   new branch and begin work.
    ```
 
 ### OpenAI Codex App
@@ -91,7 +107,10 @@ branches, editing issues, writing changelogs, and preparing public-safe PRs.
 3. Invoke:
 
    ```text
-   Use $using-github for the workflow described above.
+   [$github-flows:using-github]
+
+   New issue: simplify the README examples. When the issue is created, create a
+   new branch and begin work.
    ```
 
 ### GitHub Copilot

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Get from zero to a real invocation in under a minute (assumes [Claude Code](http
    ```text
    /using-github
 
-   New issue: tried the github-flows quick start. When the issue is created,
-   start a branch for it.
+   New issue: the install instructions mention a command that no longer works.
+   When the issue is created, start a branch to fix the docs.
    ```
 
 The guide points the agent to the correct workflow for filing issues, starting
@@ -77,8 +77,8 @@ branches, editing issues, writing changelogs, and preparing public-safe PRs.
    ```text
    /using-github
 
-   New issue: tried the github-flows install steps. When the issue is created,
-   start a branch for it.
+   New issue: the install instructions mention a command that no longer works.
+   When the issue is created, start a branch to fix the docs.
    ```
 
 ### OpenAI Codex CLI
@@ -96,8 +96,8 @@ branches, editing issues, writing changelogs, and preparing public-safe PRs.
    ```text
    [$github-flows:using-github]
 
-   New issue: simplify the README examples. When the issue is created, create a
-   new branch and begin work.
+   New issue: the install instructions mention a command that no longer works.
+   When the issue is created, create a new branch and begin work.
    ```
 
 ### OpenAI Codex App
@@ -109,8 +109,8 @@ branches, editing issues, writing changelogs, and preparing public-safe PRs.
    ```text
    [$github-flows:using-github]
 
-   New issue: simplify the README examples. When the issue is created, create a
-   new branch and begin work.
+   New issue: the install instructions mention a command that no longer works.
+   When the issue is created, create a new branch and begin work.
    ```
 
 ### GitHub Copilot

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ Get from zero to a real invocation in under a minute (assumes [Claude Code](http
    ```text
    /using-github
 
-   New issue: the install instructions mention a command that no longer works.
-   When the issue is created, start a branch to fix the docs.
+   New issue: the homepage CTA button is broken.
+
+   Create a new branch then fix.
    ```
 
 The guide points the agent to the correct workflow for filing issues, starting
@@ -77,8 +78,9 @@ branches, editing issues, writing changelogs, and preparing public-safe PRs.
    ```text
    /using-github
 
-   New issue: the install instructions mention a command that no longer works.
-   When the issue is created, start a branch to fix the docs.
+   New issue: the homepage CTA button is broken.
+
+   Create a new branch then fix.
    ```
 
 ### OpenAI Codex CLI
@@ -96,8 +98,9 @@ branches, editing issues, writing changelogs, and preparing public-safe PRs.
    ```text
    [$github-flows:using-github]
 
-   New issue: the install instructions mention a command that no longer works.
-   When the issue is created, create a new branch and begin work.
+   New issue: the homepage CTA button is broken.
+
+   Create a new branch then fix.
    ```
 
 ### OpenAI Codex App
@@ -109,8 +112,9 @@ branches, editing issues, writing changelogs, and preparing public-safe PRs.
    ```text
    [$github-flows:using-github]
 
-   New issue: the install instructions mention a command that no longer works.
-   When the issue is created, create a new branch and begin work.
+   New issue: the homepage CTA button is broken.
+
+   Create a new branch then fix.
    ```
 
 ### GitHub Copilot

--- a/docs/superpowers/plans/2026-04-27-18-simplify-readme-skill-invocation-examples-plan.md
+++ b/docs/superpowers/plans/2026-04-27-18-simplify-readme-skill-invocation-examples-plan.md
@@ -1,0 +1,166 @@
+# Plan: Simplify README skill invocation examples [#18](https://github.com/patinaproject/github-flows/issues/18)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:executing-plans` to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update README skill examples so the skill list shows what users type
+and includes a concrete `Using GitHub` router example.
+
+**Architecture:** Keep the change README-only. Treat the README as the public
+interface: simplify the top-level skill inventory, preserve installation
+commands, and add a Codex-style example for `$github-flows:using-github`.
+
+**Tech Stack:** Markdown, `markdownlint-cli2`, `rg`, Git.
+
+---
+
+## File Structure
+
+- Modify `README.md`: simplify skill invocations and add a concrete
+  `Using GitHub` example.
+
+## Task 1: Simplify The README Skill List
+
+**Files:**
+
+- Modify: `README.md`
+
+- [ ] **Step 1: Inspect the existing skill list**
+
+Run:
+
+```bash
+sed -n '1,80p' README.md
+```
+
+Expected: the "What you get" list currently uses plugin-qualified names such
+as `/github-flows:new-issue`.
+
+- [ ] **Step 2: Update the "What you get" list**
+
+Replace the current bullets with:
+
+```markdown
+- **`/using-github`** — Start here for GitHub work. It reads repository rules
+  and routes issue, branch, PR, and changelog tasks to the right workflow.
+- **`/new-issue`** — File a new GitHub issue with smart label selection,
+  duplicate detection, and a public-repo leak guard.
+- **`/edit-issue`** — Edit an existing issue's title, body, labels, assignees,
+  milestone, state, close reason, or relationships, preferring GraphQL where
+  REST falls short.
+- **`/new-branch`** — Start work on an issue: branch from the default branch as
+  `<issue-number>-<kebab-title>`, rebase, and install dependencies via the
+  highest-priority lockfile.
+- **`/write-changelog`** — Render a user-facing changelog from a GitHub
+  milestone, sourced from closed issues and their merging PRs.
+```
+
+Expected: AC-18-1 is satisfied for the main skill list.
+
+## Task 2: Add A Concrete Using GitHub Example
+
+**Files:**
+
+- Modify: `README.md`
+
+- [ ] **Step 1: Update Quick Start examples**
+
+In the "Quick start" section, keep marketplace and plugin install commands
+unchanged. Change the example invocation to use `/using-github` as the
+human-facing router:
+
+```text
+/using-github
+
+New issue: tried the github-flows quick start. When the issue is created, start
+a branch for it.
+```
+
+Expected: the quick start demonstrates the router as the first skill for
+multi-step GitHub work without changing plugin installation syntax.
+
+- [ ] **Step 2: Update Claude Code install example**
+
+In the Claude Code install subsection, change the sample invocation to:
+
+```text
+/using-github
+
+New issue: tried the github-flows install steps. When the issue is created,
+start a branch for it.
+```
+
+Expected: Claude Code examples use slash-command syntax without the
+`github-flows:` prefix.
+
+- [ ] **Step 3: Update Codex examples**
+
+In both Codex subsections, replace the generic `$github-flows` wording with a
+specific router example:
+
+```text
+[$github-flows:using-github]
+
+New issue: simplify the README examples. When the issue is created, create a
+new branch and begin work.
+```
+
+Expected: AC-18-2 is satisfied by a concrete `Using GitHub` example similar to
+an explicit skill invocation.
+
+## Task 3: Verify README Copy And Markdown
+
+**Files:**
+
+- Modify: `README.md`
+
+- [ ] **Step 1: Review remaining `github-flows:` matches**
+
+Run:
+
+```bash
+rg 'github-flows:' README.md
+```
+
+Expected: remaining matches appear only in Codex-style skill reference examples
+or other runtime-specific syntax, not in the top-level skill list.
+
+- [ ] **Step 2: Verify `Using GitHub` discoverability**
+
+Run:
+
+```bash
+rg 'using-github|Using GitHub|/using-github' README.md
+```
+
+Expected: the router skill appears in the skill list and concrete examples.
+
+- [ ] **Step 3: Run markdown lint**
+
+Run:
+
+```bash
+pnpm lint:md
+```
+
+Expected: `Summary: 0 error(s)`.
+
+- [ ] **Step 4: Commit implementation**
+
+Run:
+
+```bash
+git add README.md
+git commit -m "docs: #18 simplify README skill examples"
+```
+
+Expected: the commit succeeds after the pre-commit hook runs markdownlint and
+version checks.
+
+## Self-Review
+
+- Spec coverage: Task 1 covers AC-18-1, Task 2 covers AC-18-2, and Task 3
+  covers AC-18-3.
+- Placeholder scan: no placeholders are present.
+- Scope check: this plan is README-only, matching the approved design.

--- a/docs/superpowers/specs/2026-04-27-18-simplify-readme-skill-invocation-examples-design.md
+++ b/docs/superpowers/specs/2026-04-27-18-simplify-readme-skill-invocation-examples-design.md
@@ -1,0 +1,115 @@
+# Design: Simplify README skill invocation examples [#18](https://github.com/patinaproject/github-flows/issues/18)
+
+> Recommended skill: `superpowers:brainstorming`. The Brainstormer role for this
+> issue uses that discipline to settle README wording and scope before
+> implementation. The design is intentionally small because the issue changes
+> documentation examples, not skill behavior.
+
+## Intent
+
+Make the README examples match what users actually type. The main skill list
+should stop displaying the plugin-qualified `github-flows:` prefix, and the
+README should include a concrete `Using GitHub` example that shows how to route
+GitHub work through the umbrella skill.
+
+## Requirements
+
+- Update only user-facing README guidance unless implementation discovers a
+  directly related markdown consistency issue.
+- In the README skill list, display the user-facing skill names or invocations
+  without `github-flows:`.
+- Preserve the existing skill outcomes: new issue filing, issue editing, branch
+  creation, changelog writing, and the `Using GitHub` router.
+- Add a concrete `Using GitHub` example similar to an explicit skill invocation
+  so Codex-style users can see how to ask for the router skill by name.
+- Keep editor-specific examples honest: slash-command examples should remain in
+  Claude Code sections when they are Claude Code-specific, while Codex examples
+  should use the `$github-flows:using-github` style users actually type.
+- Keep the README markdownlint-clean.
+
+## Approaches Considered
+
+### Recommended: README-Only Invocation Cleanup
+
+Update the README's "What you get" list and relevant examples so they center on
+user-facing names. Use `/new-issue`, `/edit-issue`, `/new-branch`,
+`/write-changelog`, and `/using-github` where slash-command syntax is the
+surface, and include a Codex-style `$github-flows:using-github` example where
+that syntax is the surface.
+
+This is the smallest change that satisfies the issue while preserving the
+plugin package name and the existing installation guidance.
+
+### Alternative: Rename Skills or Plugin Metadata
+
+The repository could rename commands or alter plugin metadata so the public
+runtime no longer exposes `github-flows:` anywhere.
+
+That is out of scope. The issue is about README simplification, not runtime
+behavior or packaging.
+
+### Alternative: Remove Slash Commands From the README
+
+The README could describe only plain-language skill names and omit concrete
+invocations.
+
+That would avoid prefix confusion, but it would make the README less useful for
+people trying to copy a real command or prompt.
+
+## Design
+
+Revise the README around two principles:
+
+- The top-level skill inventory uses the terms users would type first:
+  `/using-github`, `/new-issue`, `/edit-issue`, `/new-branch`, and
+  `/write-changelog`.
+- Runtime-specific examples can show their native syntax, including an explicit
+  Codex-style `[$github-flows:using-github]` invocation example for the router
+  skill.
+
+The `Using GitHub` example should be close to the user's request shape:
+
+```text
+[$github-flows:using-github]
+
+New issue: simplify the README examples. When the issue is created, create a
+new branch and begin work.
+```
+
+The exact rendered example may omit brackets or path-like metadata if that is
+clearer in README prose, but it should demonstrate the router skill as the
+entry point for a multi-step GitHub task.
+
+## Acceptance Criteria
+
+- AC-18-1: Given a user reads the README skill list, when they scan the
+  available skills, then the listed invocations omit the `github-flows:` prefix
+  and show what users would actually type.
+- AC-18-2: Given a user wants to route repository work through the GitHub
+  workflow skill, when they read the README examples, then they see a concrete
+  `Using GitHub` example similar to an explicit skill invocation.
+- AC-18-3: Given the README examples are updated, when markdown lint runs, then
+  the README passes the repository markdown checks.
+
+## Testing
+
+- Run `pnpm lint:md`.
+- Run `rg 'github-flows:' README.md` and review any remaining matches to ensure
+  they appear only where runtime-specific syntax or package names require them.
+- Run `rg 'using-github|Using GitHub|/using-github' README.md` to verify the
+  router skill is discoverable.
+- Review `README.md` directly to confirm the examples distinguish plugin
+  install syntax from skill invocation syntax.
+
+## Out of Scope
+
+- Changing skill behavior or file layout under `skills/`.
+- Changing plugin install commands, marketplace names, or package metadata.
+- Updating editor-generated guidance outside `README.md`.
+- Opening or changing release automation.
+
+## Concerns
+
+No approval-relevant concerns remain. The main implementation risk is making
+the examples too generic, so the plan should include a direct README review for
+copy-paste usefulness after lint passes.


### PR DESCRIPTION
## Summary

- Simplifies the README skill inventory to show `/using-github`, `/new-issue`,
  `/edit-issue`, `/new-branch`, and `/write-changelog`.
- Adds concrete `/using-github` and `[$github-flows:using-github]` examples for
  Claude Code and Codex users.
- Adds Superteam design and implementation-plan artifacts for issue #18.

## Linked issue

- Closes #18

## Acceptance criteria

### AC-18-1

The README skill list now omits the `github-flows:` prefix and shows the
invocations users would type.

- [x] Markdown evidence — Codex | local worktree | @tlmader | 2026-04-27T07:48:46Z

### AC-18-2

The README includes concrete `Using GitHub` examples, including explicit
Codex-style `[$github-flows:using-github]` invocations.

- [x] Markdown evidence — Codex | local worktree | @tlmader | 2026-04-27T07:48:46Z

### AC-18-3

Markdown lint passes for the updated README and Superteam artifacts.

- [x] Validation evidence — Codex | local worktree | @tlmader | 2026-04-27T07:48:46Z

## Validation

- `rg 'github-flows:' README.md`
- `rg 'using-github|Using GitHub|/using-github' README.md`
- `pnpm lint:md`

## Docs updated

- [x] Updated in this PR
