### PR TITLE
docs: #19 use complete company name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Slash-command skills that let coding agents file issues, start branches, edit is
 
 Get from zero to a real invocation in under a minute (assumes [Claude Code](https://docs.claude.com/claude-code)):
 
-1. Add the Patina marketplace:
+1. Add the Patina Project marketplace:
 
    ```text
    /plugin marketplace add patinaproject/skills
@@ -61,7 +61,7 @@ branches, editing issues, writing changelogs, and preparing public-safe PRs.
 
 ### Claude Code
 
-1. Register the Patina marketplace:
+1. Register the Patina Project marketplace:
 
    ```text
    /plugin marketplace add patinaproject/skills
@@ -85,7 +85,7 @@ branches, editing issues, writing changelogs, and preparing public-safe PRs.
 
 ### OpenAI Codex CLI
 
-1. Register the Patina marketplace:
+1. Register the Patina Project marketplace:
 
    ```bash
    codex plugin marketplace add patinaproject/skills
@@ -220,7 +220,7 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ## Related
 
-- [Patina marketplace (`patinaproject/skills`)](https://github.com/patinaproject/skills)
+- [Patina Project marketplace (`patinaproject/skills`)](https://github.com/patinaproject/skills)
 - [Contributing](./CONTRIBUTING.md)
 - [Security policy](./SECURITY.md)
 - [Release process](./RELEASING.md)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -73,7 +73,7 @@ Wire it into `.github/workflows/release.yml` by replacing the `token:` input on 
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 ```
 
-The default code path stays `secrets.GITHUB_TOKEN` in the emitted template so forks outside Patina don't need to provision a Patina-specific secret.
+The default code path stays `secrets.GITHUB_TOKEN` in the emitted template so forks outside Patina Project don't need to provision a Patina Project-specific secret.
 
 ### Tag ruleset caution
 
@@ -120,7 +120,7 @@ Determined from commit types — no human choice:
 
 ## Distribution via `patinaproject/skills`
 
-When a release is published **and the repository owner is `patinaproject`**, the release workflow automatically dispatches `plugin-release-bump.yml` on `patinaproject/skills`. That marketplace repo opens (or updates) a PR bumping this plugin's pinned `ref` across every Patina marketplace manifest.
+When a release is published **and the repository owner is `patinaproject`**, the release workflow automatically dispatches `plugin-release-bump.yml` on `patinaproject/skills`. That marketplace repo opens (or updates) a PR bumping this plugin's pinned `ref` across every Patina Project marketplace manifest.
 
 No per-repo opt-in is required — the `github.repository_owner == 'patinaproject'` check on the `notify-patinaproject-skills` job gates this behavior. Forks in other orgs skip the job entirely and don't need any of the setup below.
 

--- a/docs/superpowers/plans/2026-04-26-4-make-the-readme-awesome-plan.md
+++ b/docs/superpowers/plans/2026-04-26-4-make-the-readme-awesome-plan.md
@@ -131,7 +131,7 @@ git commit -m "docs: #4 add What you get skills section to README"
 
 Get from zero to a real invocation in under a minute (assumes [Claude Code](https://docs.claude.com/claude-code)):
 
-1. Add the Patina marketplace:
+1. Add the Patina Project marketplace:
 
    ```text
    /plugin marketplace add patinaproject/skills
@@ -223,7 +223,7 @@ git commit -m "docs: #4 collapse README install matrix into details block"
 ```markdown
 ## Related
 
-- [Patina marketplace (`patinaproject/skills`)](https://github.com/patinaproject/skills)
+- [Patina Project marketplace (`patinaproject/skills`)](https://github.com/patinaproject/skills)
 - [Contributing](./CONTRIBUTING.md)
 - [Security policy](./SECURITY.md)
 - [Release process](./RELEASING.md)

--- a/docs/superpowers/plans/2026-04-27-19-use-patina-project-as-the-complete-company-name-plan.md
+++ b/docs/superpowers/plans/2026-04-27-19-use-patina-project-as-the-complete-company-name-plan.md
@@ -1,0 +1,163 @@
+# Plan: Use Patina Project as the complete company name [#19](https://github.com/patinaproject/github-flows/issues/19)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:executing-plans` to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update public documentation so company-display prose uses "Patina
+Project" while `patina` identifiers remain unchanged.
+
+**Architecture:** Treat this as a targeted Markdown audit. First capture the
+current whole-word `Patina` matches, then update only company-display prose,
+then rerun the audit and lint to prove identifiers are preserved.
+
+**Tech Stack:** Markdown, `rg`, `sed`, `markdownlint-cli2`, Git.
+
+---
+
+## File Structure
+
+- Modify `README.md`: update marketplace display wording and related link text.
+- Modify `RELEASING.md`: update company-display prose in release guidance.
+- Modify `docs/superpowers/specs/2026-04-26-1-bootstrap-and-ship-skills-design.md`:
+  update the historical "Patina baseline" display wording.
+- Modify `docs/superpowers/specs/2026-04-26-4-make-the-readme-awesome-design.md`:
+  update historical README design copy that names the marketplace and plugins.
+- Modify `docs/superpowers/plans/2026-04-26-4-make-the-readme-awesome-plan.md`:
+  update historical README plan copy that names the marketplace.
+
+## Task 1: Capture The Failing Audit
+
+**Files:**
+
+- Inspect: `README.md`
+- Inspect: `RELEASING.md`
+- Inspect: `docs/**/*.md`
+
+- [ ] **Step 1: Run the whole-word audit**
+
+Run:
+
+```bash
+rg -n '\bPatina\b|patina' README.md RELEASING.md docs/**/*.md
+```
+
+Expected: output includes company-display prose such as "Patina marketplace",
+"Patina plugins", "outside Patina", and "Patina baseline", plus preserved
+identifier matches such as `patinaproject/skills` and
+`patina-project-automation`.
+
+- [ ] **Step 2: Classify matches before editing**
+
+Classify these company-display matches for editing:
+
+```text
+README.md: Add/Register the Patina marketplace
+README.md: Patina marketplace link text
+RELEASING.md: forks outside Patina
+RELEASING.md: Patina marketplace manifest
+docs/superpowers/specs/2026-04-26-1-bootstrap-and-ship-skills-design.md: Patina baseline
+docs/superpowers/specs/2026-04-26-4-make-the-readme-awesome-design.md: Patina marketplace / Patina plugins
+docs/superpowers/plans/2026-04-26-4-make-the-readme-awesome-plan.md: Add the Patina marketplace / Patina marketplace link text
+```
+
+Expected: identifiers such as `patinaproject/skills`,
+`github-flows@patinaproject-skills`, `patina-project-automation`, URLs, and
+repo slugs are not selected for editing.
+
+## Task 2: Update Company-Display Prose
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `RELEASING.md`
+- Modify: `docs/superpowers/specs/2026-04-26-1-bootstrap-and-ship-skills-design.md`
+- Modify: `docs/superpowers/specs/2026-04-26-4-make-the-readme-awesome-design.md`
+- Modify: `docs/superpowers/plans/2026-04-26-4-make-the-readme-awesome-plan.md`
+
+- [ ] **Step 1: Replace company-display references**
+
+Make these wording-only replacements:
+
+```text
+Patina marketplace -> Patina Project marketplace
+Patina plugins -> Patina Project plugins
+outside Patina -> outside Patina Project
+Patina baseline -> Patina Project baseline
+Patina marketplace manifest -> Patina Project marketplace manifest
+```
+
+Expected: public-facing sentences now use "Patina Project" as the complete
+company name.
+
+- [ ] **Step 2: Preserve identifiers**
+
+Do not edit these identifier-like strings:
+
+```text
+patinaproject
+patinaproject/skills
+github-flows@patinaproject-skills
+patina-project-automation
+https://github.com/patinaproject/...
+```
+
+Expected: AC-19-2 remains satisfied after the prose cleanup.
+
+## Task 3: Verify Acceptance Criteria
+
+**Files:**
+
+- Inspect: changed Markdown files
+
+- [ ] **Step 1: Rerun the audit**
+
+Run:
+
+```bash
+rg -n '\bPatina\b|patina' README.md RELEASING.md docs/**/*.md
+```
+
+Expected: remaining whole-word "Patina" matches are either "Patina Project" or
+intentional references in issue #19's design artifact; remaining lowercase
+`patina` matches are preserved identifiers.
+
+- [ ] **Step 2: Review the diff**
+
+Run:
+
+```bash
+git diff -- README.md RELEASING.md docs/
+```
+
+Expected: diff contains wording-only documentation changes and no identifier
+renames.
+
+- [ ] **Step 3: Run markdown lint**
+
+Run:
+
+```bash
+pnpm lint:md
+```
+
+Expected: markdownlint reports zero errors.
+
+- [ ] **Step 4: Commit implementation**
+
+Run:
+
+```bash
+git add README.md RELEASING.md docs/superpowers/specs/2026-04-26-1-bootstrap-and-ship-skills-design.md docs/superpowers/specs/2026-04-26-4-make-the-readme-awesome-design.md docs/superpowers/plans/2026-04-26-4-make-the-readme-awesome-plan.md
+git commit -m "docs: #19 use complete company name"
+```
+
+Expected: the commit succeeds after pre-commit markdownlint and version checks.
+
+## Self-Review
+
+- Spec coverage: Task 2 covers AC-19-1, and Task 3 explicitly verifies both
+  AC-19-1 and AC-19-2.
+- Placeholder scan: no placeholder instructions are present.
+- Scope check: the plan changes Markdown wording only and preserves all
+  machine-readable identifiers named in the approved design.

--- a/docs/superpowers/plans/2026-04-27-19-use-patina-project-as-the-complete-company-name-plan.md
+++ b/docs/superpowers/plans/2026-04-27-19-use-patina-project-as-the-complete-company-name-plan.md
@@ -20,7 +20,7 @@ then rerun the audit and lint to prove identifiers are preserved.
 - Modify `README.md`: update marketplace display wording and related link text.
 - Modify `RELEASING.md`: update company-display prose in release guidance.
 - Modify `docs/superpowers/specs/2026-04-26-1-bootstrap-and-ship-skills-design.md`:
-  update the historical "Patina baseline" display wording.
+  update the historical baseline display wording.
 - Modify `docs/superpowers/specs/2026-04-26-4-make-the-readme-awesome-design.md`:
   update historical README design copy that names the marketplace and plugins.
 - Modify `docs/superpowers/plans/2026-04-26-4-make-the-readme-awesome-plan.md`:
@@ -42,23 +42,22 @@ Run:
 rg -n '\bPatina\b|patina' README.md RELEASING.md docs/**/*.md
 ```
 
-Expected: output includes company-display prose such as "Patina marketplace",
-"Patina plugins", "outside Patina", and "Patina baseline", plus preserved
-identifier matches such as `patinaproject/skills` and
-`patina-project-automation`.
+Expected: output includes shortened company-display prose for marketplace,
+plugin, baseline, and "outside the company" wording, plus preserved identifier
+matches such as `patinaproject/skills` and `patina-project-automation`.
 
 - [ ] **Step 2: Classify matches before editing**
 
 Classify these company-display matches for editing:
 
 ```text
-README.md: Add/Register the Patina marketplace
-README.md: Patina marketplace link text
-RELEASING.md: forks outside Patina
-RELEASING.md: Patina marketplace manifest
-docs/superpowers/specs/2026-04-26-1-bootstrap-and-ship-skills-design.md: Patina baseline
-docs/superpowers/specs/2026-04-26-4-make-the-readme-awesome-design.md: Patina marketplace / Patina plugins
-docs/superpowers/plans/2026-04-26-4-make-the-readme-awesome-plan.md: Add the Patina marketplace / Patina marketplace link text
+README.md: add/register marketplace wording
+README.md: marketplace link text
+RELEASING.md: forks outside the company wording
+RELEASING.md: marketplace manifest wording
+docs/superpowers/specs/2026-04-26-1-bootstrap-and-ship-skills-design.md: baseline wording
+docs/superpowers/specs/2026-04-26-4-make-the-readme-awesome-design.md: marketplace/plugin wording
+docs/superpowers/plans/2026-04-26-4-make-the-readme-awesome-plan.md: marketplace wording and link text
 ```
 
 Expected: identifiers such as `patinaproject/skills`,
@@ -80,11 +79,11 @@ repo slugs are not selected for editing.
 Make these wording-only replacements:
 
 ```text
-Patina marketplace -> Patina Project marketplace
-Patina plugins -> Patina Project plugins
-outside Patina -> outside Patina Project
-Patina baseline -> Patina Project baseline
-Patina marketplace manifest -> Patina Project marketplace manifest
+marketplace display wording -> Patina Project marketplace
+plugin display wording -> Patina Project plugins
+outside-company display wording -> outside Patina Project
+baseline display wording -> Patina Project baseline
+marketplace manifest display wording -> Patina Project marketplace manifest
 ```
 
 Expected: public-facing sentences now use "Patina Project" as the complete

--- a/docs/superpowers/specs/2026-04-26-1-bootstrap-and-ship-skills-design.md
+++ b/docs/superpowers/specs/2026-04-26-1-bootstrap-and-ship-skills-design.md
@@ -2,7 +2,7 @@
 
 ## Intent
 
-Ship the four GitHub-ergonomics skills the `github-flows` plugin exists to deliver, on top of the Patina baseline already scaffolded in this branch. Each skill is a thin, agent-callable Markdown contract (no executable code), discoverable via slash-command, and uses `gh` + GraphQL where the REST CLI is too coarse.
+Ship the four GitHub-ergonomics skills the `github-flows` plugin exists to deliver, on top of the Patina Project baseline already scaffolded in this branch. Each skill is a thin, agent-callable Markdown contract (no executable code), discoverable via slash-command, and uses `gh` + GraphQL where the REST CLI is too coarse.
 
 This design covers the four skill workflows plus the two supporting docs (`.github/LABELS.md`, `docs/issue-filing-style.md`) and the cross-cutting patterns shared between them. Phase 1 (the bootstrap pass) is already committed at `cf3a49b` and is in-scope for the same PR but not re-designed here.
 

--- a/docs/superpowers/specs/2026-04-26-4-make-the-readme-awesome-design.md
+++ b/docs/superpowers/specs/2026-04-26-4-make-the-readme-awesome-design.md
@@ -116,7 +116,7 @@ demo → value → trial → depth. Sections in order:
    slash-command invocation, and a one-line outcome. See "Skill summaries"
    below for the canonical copy.
 5. **Quick start.** A 60-second flow that assumes Claude Code, the most
-   common entry point. Three numbered steps: register the Patina
+   common entry point. Three numbered steps: register the Patina Project
    marketplace, install the plugin, run a real invocation against an
    example issue (for example,
    `/github-flows:new-issue` against this repo's issue tracker). No
@@ -128,7 +128,7 @@ demo → value → trial → depth. Sections in order:
    to `docs/install.md` and link. The `<details>` block is the preferred
    path because it keeps everything discoverable on one page.)
 7. **Related / Links.** A short closing section consolidating links to the
-   Patina marketplace (`patinaproject/skills`), other Patina plugins, and
+   Patina Project marketplace (`patinaproject/skills`), other Patina Project plugins, and
    the existing `CONTRIBUTING.md`, `SECURITY.md`, and `RELEASING.md` files.
 8. **License.** A one-line pointer to `LICENSE` (MIT).
 

--- a/docs/superpowers/specs/2026-04-27-19-use-patina-project-as-the-complete-company-name-design.md
+++ b/docs/superpowers/specs/2026-04-27-19-use-patina-project-as-the-complete-company-name-design.md
@@ -1,0 +1,84 @@
+# Design: Use Patina Project as the complete company name [#19](https://github.com/patinaproject/github-flows/issues/19)
+
+> Recommended skill: `superpowers:brainstorming`. The Brainstormer role for this
+> issue uses that discipline to separate company-display wording from stable
+> repository, marketplace, package, bot, and URL identifiers.
+
+## Intent
+
+Update public-facing documentation so sentences that refer to the company use
+the complete name "Patina Project" instead of the shortened display name
+"Patina", while preserving machine-readable identifiers and historical slugs.
+
+## Requirements
+
+- Replace public-facing company-display references to "Patina" with "Patina
+  Project".
+- Preserve repository owners, repository slugs, URLs, package names, domains,
+  marketplace identifiers, bot names, and other machine-readable identifiers
+  that contain `patina` or `patinaproject`.
+- Audit the known affected surfaces from issue #19:
+  - `README.md`
+  - `RELEASING.md`
+  - `docs/superpowers/specs/2026-04-26-1-bootstrap-and-ship-skills-design.md`
+  - `docs/superpowers/specs/2026-04-26-4-make-the-readme-awesome-design.md`
+  - `docs/superpowers/plans/2026-04-26-4-make-the-readme-awesome-plan.md`
+- Treat historical Superpowers docs as in scope when they are public-facing docs
+  that contain company-display wording.
+- Keep markdown lint clean.
+- Do not rename GitHub organization/repository references, package names,
+  domains, plugin identifiers, bot identities, or release workflow secrets.
+- Preserve issue #19's cross-repo context as a plain reference to
+  `patinaproject/bootstrap#46`.
+
+## Design
+
+Use a targeted documentation audit rather than a global replacement. Search for
+whole-word `Patina` in public Markdown docs, inspect each match, and classify it
+as one of two cases:
+
+- **Company-display prose:** update to "Patina Project". Examples include
+  "Patina marketplace", "Patina plugins", "outside Patina", and "Patina
+  baseline".
+- **Identifier or proper machine name:** preserve as-is. Examples include
+  `patinaproject/skills`, `patina-project-automation`, URLs, package names, and
+  code examples.
+
+The implementation should update the known affected docs plus any directly
+related public docs discovered by the audit. It should not churn unrelated
+wording, restructure old plans, or normalize lowercase identifier examples.
+
+## Acceptance Criteria
+
+### AC-19-1
+
+Given a public-facing docs sentence refers to the company as "Patina", when the
+wording is updated, then it uses "Patina Project" instead.
+
+### AC-19-2
+
+Given a repository slug, URL, package name, or identifier contains `patina`,
+when the audit is performed, then that identifier is preserved.
+
+## Verification
+
+- Run `rg -n '\bPatina\b|patina' README.md RELEASING.md docs/**/*.md` and
+  review remaining matches for identifier-safe usage or intentional historical
+  references.
+- Run `pnpm lint:md`.
+- Review the changed files with `git diff -- README.md RELEASING.md docs/` to
+  confirm the edits are wording-only and do not rename identifiers.
+
+## Out of Scope
+
+- Renaming the GitHub organization, repository slugs, package names, URLs,
+  domains, marketplace identifiers, bot names, or release workflow secrets.
+- Changing runtime behavior in `skills/`.
+- Changing release automation behavior.
+- Updating issue or PR labels.
+
+## Concerns
+
+No approval-relevant concerns remain. The main execution risk is accidentally
+editing identifiers during the wording cleanup, so the plan should include an
+explicit post-edit audit of remaining `Patina` and `patina` matches.

--- a/docs/superpowers/specs/2026-04-27-19-use-patina-project-as-the-complete-company-name-design.md
+++ b/docs/superpowers/specs/2026-04-27-19-use-patina-project-as-the-complete-company-name-design.md
@@ -37,9 +37,8 @@ Use a targeted documentation audit rather than a global replacement. Search for
 whole-word `Patina` in public Markdown docs, inspect each match, and classify it
 as one of two cases:
 
-- **Company-display prose:** update to "Patina Project". Examples include
-  "Patina marketplace", "Patina plugins", "outside Patina", and "Patina
-  baseline".
+- **Company-display prose:** update shortened marketplace, plugin, baseline,
+  and "outside the company" wording to use "Patina Project".
 - **Identifier or proper machine name:** preserve as-is. Examples include
   `patinaproject/skills`, `patina-project-automation`, URLs, package names, and
   code examples.
@@ -81,4 +80,4 @@ when the audit is performed, then that identifier is preserved.
 
 No approval-relevant concerns remain. The main execution risk is accidentally
 editing identifiers during the wording cleanup, so the plan should include an
-explicit post-edit audit of remaining `Patina` and `patina` matches.
+explicit post-edit audit of remaining `Patina Project` and `patina` matches.


### PR DESCRIPTION
# Pull Request

## Summary

- Update public docs to use "Patina Project" for company-display prose.
- Preserve `patinaproject`, `patina-project-automation`, marketplace paths, URLs, and other identifiers.
- Add Superpowers design and plan artifacts for issue #19.

## Linked issue

- Closes #19

## Acceptance criteria

### AC-19-1

Public-facing documentation sentences that referred to the company as "Patina" now use "Patina Project".

- [x] Docs audit — local | macOS, pnpm 10.33.2 | @tlmader | 2026-04-27T08:19:04Z
- [ ] Manual test: 1. Review `README.md`, `RELEASING.md`, and changed `docs/superpowers/**` files. 2. Confirm company-display prose says "Patina Project" where the issue identified shortened "Patina" wording.

### AC-19-2

Repository slugs, URLs, package names, marketplace references, and other `patina` identifiers remain unchanged.

- [x] Identifier audit — local | macOS, pnpm 10.33.2 | @tlmader | 2026-04-27T08:19:04Z
- [ ] Manual test: 1. Review remaining `patina` matches from `rg -n '\bPatina\b|patina' README.md RELEASING.md docs/**/*.md`. 2. Confirm lowercase `patina` matches are preserved identifiers or intentional repository references.

## Validation

- `rg -n '\bPatina\b|patina' README.md RELEASING.md docs/**/*.md`
- `pnpm lint:md`
- `git diff --check`
- `pnpm install`

## Docs updated

- [x] Updated in this PR
