### PR TITLE
chore: #26 realign repo to bootstrap 1.3.0

### DIFF
--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -1,15 +1,15 @@
 # Labels
 
-This file is the canonical inventory of GitHub issue and PR labels for
-`patinaproject/using-github`. The `using-github` skill reads this file at
-runtime and never hardcodes label names.
+This file documents when to apply each GitHub issue and PR label in
+`patinaproject/using-github`. For the authoritative runtime inventory, run
+`gh label list --json name,description`.
 
 ## Labels
 
 | Name | Description | Color |
 |------|-------------|-------|
-| `autorelease: pending` | Reserved for Release Please. Applied automatically to the open release PR. Do not apply or remove manually. | `c5def5` |
-| `autorelease: tagged` | Reserved for Release Please. Applied automatically after a release tag is cut. Do not apply or remove manually. | `c5def5` |
+| `autorelease: pending` | Reserved for Release Please. Applied automatically to the open release PR. Do not apply or remove manually. | `ededed` |
+| `autorelease: tagged` | Reserved for Release Please. Applied automatically after a release tag is cut. Do not apply or remove manually. | `ededed` |
 | `bug` | Something isn't working. | `d73a4a` |
 | `documentation` | Improvements or additions to documentation. | `0075ca` |
 | `duplicate` | This issue or pull request already exists. | `cfd3d7` |
@@ -26,7 +26,7 @@ runtime and never hardcodes label names.
 2. After merge, sync the change to the GitHub remote with `gh label create` / `gh label edit` (or via the Settings UI). A future follow-up will automate this from CI; until then it is manual.
 3. Names are sorted alphabetically (case-insensitive). Keep the table sorted on every change.
 
-## Reserved labels
+### Release-please (tool-managed)
 
 The `autorelease: pending` and `autorelease: tagged` labels are owned by Release Please:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,15 @@
 name: Release
 
-# release-please requires a run on push to main to cut the tag after
-# the release PR merges. workflow_dispatch is kept as a manual escape hatch.
+# Triggered on every push to `main`, with workflow_dispatch available as a
+# recovery escape hatch. release-please is idempotent: on regular feature/fix
+# merges it opens or refreshes the standing release PR; on the release-PR merge
+# it sees the merged PR (label `autorelease: pending`) and cuts the tag,
+# publishes the release, and dispatches the marketplace bump on
+# patinaproject/skills. Manual dispatch runs the same path. See RELEASING.md.
 on:
+  workflow_dispatch:
   push:
     branches: [main]
-  workflow_dispatch:
 
 permissions:
   contents: write

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,13 +4,32 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ## How it works
 
-1. On every push to `main`, the `Release` workflow runs `release-please`. The same workflow can also be triggered manually from **Actions → Release → Run workflow** as an escape hatch — use it to seed the very first release PR before any push to `main`, or to re-run after a transient failure.
-2. `release-please` scans Conventional Commits since the last tag.
-3. It opens (or updates) a standing **"chore: release X.Y.Z"** PR that:
+The `Release` workflow runs on every push to `main`. Cutting a release is the natural by-product of merging PRs:
+
+1. **Merge any PR into `main`.** The push event runs `Release`. `release-please` scans Conventional Commits since the last tag and opens — or updates — a standing **"chore: release X.Y.Z"** PR that:
    - Bumps `package.json` version.
    - Syncs `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` to the new version (configured in `release-please-config.json`).
    - Appends generated entries to `CHANGELOG.md`.
-4. **Clicking Merge on that PR** is the release action. It tags `vX.Y.Z` and publishes a GitHub Release with notes generated from the same commits.
+
+   Release-please attaches the `autorelease: pending` label to this PR. If there are no releasable commits since the last tag, the run no-ops.
+
+2. **Merge the release PR.** Squash-merging the PR is itself a push to `main`, so `Release` runs again. release-please now sees the merged release PR (still labeled `autorelease: pending`), creates the tag `vX.Y.Z`, publishes the GitHub Release with the Conventional-Commit-derived notes, and (on `patinaproject` plugin repos) dispatches the marketplace bump on `patinaproject/skills`. The PR's label flips to `autorelease: tagged`.
+
+The result: every merge keeps the standing release PR fresh; merging that PR cuts the release. No manual step is required during the normal flow.
+
+## Manual recovery dispatch
+
+Manual dispatch is an escape hatch, not the normal release path. Use it only when the latest automatic `Release` run was skipped, cancelled, failed for transient reasons, or needs to be retried after permissions or repository settings were fixed.
+
+Start the same workflow from the GitHub Actions UI, or run:
+
+```bash
+gh workflow run Release
+```
+
+The manual run performs the same release-please evaluation as a push-triggered run. If releasable commits exist, it opens or refreshes the standing release PR. If the release PR has already been merged and the repository state calls for a release, it can cut the tag and GitHub Release. If there is nothing to release, it no-ops.
+
+Do not use manual dispatch as the ordinary release process. Do not perform manual version bumps or local release commands.
 
 ## Prerequisites (one-time settings)
 
@@ -101,11 +120,14 @@ When enabled, GitHub refuses to run workflows that `uses:` an action by tag or b
 
 ## Semver decision
 
-Determined from commit types — no human choice:
+Determined from releasable Conventional Commit types — no human choice:
 
 - `fix:` → patch
 - `feat:` → minor
-- `feat!:` or `BREAKING CHANGE:` footer → major
+- `<type>!:` or `BREAKING CHANGE:` footer → major
+- `docs:`, `chore:`, and other non-releasable types → no version bump under this baseline
+
+If a change should produce a release, do not use a non-bumping type. For example, a Markdown-only edit to `skills/**/SKILL.md` that changes installed skill behavior should use `feat:` or `fix:`, not `docs:`.
 
 ## Keeping versions aligned between releases
 
@@ -140,5 +162,6 @@ If either secret is missing on a `patinaproject` plugin repo, the `Mint patina-p
 ## Writing commits for a clean changelog
 
 - Use Conventional Commits: `feat: #<issue> …`, `fix: #<issue> …`, etc.
+- Choose release-triggering types for product changes. Release Please can no-op when product changes are misclassified as `docs:` or `chore:`, which can skip downstream marketplace bump automation.
 - Breaking changes: prefix the type with `!` (e.g. `feat!: #123 rename foo to bar`) **and** include a `BREAKING CHANGE: …` footer in the PR body.
 - Squash-merge flow: PR titles must themselves be conventional-commit-shaped so the squash commit lands with the correct type/scope. Enforced by the `Lint PR` workflow.

--- a/docs/bootstrap-1.3.0-realignment-audit.md
+++ b/docs/bootstrap-1.3.0-realignment-audit.md
@@ -50,6 +50,19 @@ safe local documentation/workflow wording updates while preserving the
 
 - `find . -maxdepth 3 ...` confirmed required baseline files and agent-plugin
   surfaces are present.
+- `pnpm install` completed with the lockfile already up to date.
+- `pnpm exec commitlint --help` completed successfully.
+- `pnpm lint:md` completed with `0 error(s)`.
+- `echo "feat: bad" | pnpm exec commitlint` failed as expected because the
+  subject lacks a GitHub issue reference.
+- `echo "feat: #1 ok" | pnpm exec commitlint` completed successfully.
+- `pnpm check:versions` confirmed both plugin manifests match
+  `package.json` version `2.0.0`.
+- `find skills -maxdepth 2 -name SKILL.md -print` returned only
+  `skills/using-github/SKILL.md`.
+- `rg 'uses: [^#@]*@[A-Za-z0-9_.-]+$' .github/workflows || true` printed all
+  workflow action references; each `uses:` entry is pinned to a full
+  40-character commit SHA.
 - `gh repo view --json nameWithOwner,visibility,defaultBranchRef` returned
   `patinaproject/using-github`, `PUBLIC`, default branch `main`.
 - `gh api repos/:owner/:repo --jq '{allow_squash_merge, allow_merge_commit, allow_rebase_merge, squash_merge_commit_title, squash_merge_commit_message, delete_branch_on_merge, allow_update_branch}'` returned the expected Bootstrap merge settings.

--- a/docs/bootstrap-1.3.0-realignment-audit.md
+++ b/docs/bootstrap-1.3.0-realignment-audit.md
@@ -13,8 +13,8 @@ safe local documentation/workflow wording updates while preserving the
 | Area | Result | Notes |
 | --- | --- | --- |
 | Core repo tooling | Aligned | PNPM, Husky, markdownlint, commitlint, version sync scripts, and public `SECURITY.md` are present. |
-| GitHub metadata | Partially aligned | Templates and workflows are present. Local label docs need Bootstrap 1.3.0 release-label wording. Remote release labels exist but have empty descriptions. |
-| Agent and repo docs | Partially aligned | Required docs are present. `docs/file-structure.md` still mentions removed specialized skill directories. |
+| GitHub metadata | Partially aligned | Templates and workflows are present. Local label docs now match Bootstrap 1.3.0 release-label wording. Remote release labels exist but have empty descriptions. |
+| Agent and repo docs | Aligned | Required docs are present and stale removed-skill wording was refreshed. |
 | Claude configuration | Aligned | `.claude/settings.json` enables `superteam` and `superpowers`. |
 | AI platform surfaces | Aligned | Claude, Codex, Copilot, Cursor, Windsurf, release-please, and skill surfaces are present. |
 | Superpowers opt-in | Aligned | `docs/superpowers/specs/` and `docs/superpowers/plans/` exist. |
@@ -26,11 +26,10 @@ safe local documentation/workflow wording updates while preserving the
 ## Applied Local Changes
 
 - Added this Bootstrap 1.3.0 realignment audit.
-- Planned local updates:
-  - Refresh `.github/LABELS.md` release-label wording and reserved-label colors.
-  - Remove stale removed-skill wording from `docs/file-structure.md`.
-  - Refresh `RELEASING.md` release-flow guidance from the Bootstrap 1.3.0 Patina Project supplement.
-  - Refresh `.github/workflows/release.yml` trigger comment/order to match the Bootstrap 1.3.0 Patina Project supplement.
+- Refreshed `.github/LABELS.md` release-label wording and reserved-label colors.
+- Removed stale removed-skill wording from `docs/file-structure.md`.
+- Refreshed `RELEASING.md` release-flow guidance from the Bootstrap 1.3.0 Patina Project supplement.
+- Refreshed `.github/workflows/release.yml` trigger comment/order to match the Bootstrap 1.3.0 Patina Project supplement.
 
 ## Remaining Follow-Ups
 

--- a/docs/bootstrap-1.3.0-realignment-audit.md
+++ b/docs/bootstrap-1.3.0-realignment-audit.md
@@ -1,0 +1,59 @@
+# Bootstrap 1.3.0 Realignment Audit
+
+## Summary
+
+The repository is partially aligned with Bootstrap 1.3.0. Core tooling,
+plugin manifests, AI editor surfaces, workflow permissions, merge settings, and
+Superpowers scaffolding are present. This branch records the audit and applies
+safe local documentation/workflow wording updates while preserving the
+`using-github` skill contract.
+
+## Bootstrap Checks
+
+| Area | Result | Notes |
+| --- | --- | --- |
+| Core repo tooling | Aligned | PNPM, Husky, markdownlint, commitlint, version sync scripts, and public `SECURITY.md` are present. |
+| GitHub metadata | Partially aligned | Templates and workflows are present. Local label docs need Bootstrap 1.3.0 release-label wording. Remote release labels exist but have empty descriptions. |
+| Agent and repo docs | Partially aligned | Required docs are present. `docs/file-structure.md` still mentions removed specialized skill directories. |
+| Claude configuration | Aligned | `.claude/settings.json` enables `superteam` and `superpowers`. |
+| AI platform surfaces | Aligned | Claude, Codex, Copilot, Cursor, Windsurf, release-please, and skill surfaces are present. |
+| Superpowers opt-in | Aligned | `docs/superpowers/specs/` and `docs/superpowers/plans/` exist. |
+| Repository merge settings | Aligned | `gh api repos/:owner/:repo` reports the expected squash-only merge settings. |
+| Workflow permissions | Aligned | `gh api repos/:owner/:repo/actions/permissions/workflow --jq .default_workflow_permissions` returns `write`. |
+| Tag rulesets | Aligned | No tag-target rulesets were returned. |
+| Commit / PR title hygiene | Aligned with historical exception | Recent release commits use `chore: release ...`, which is expected for Release Please; other sampled commits follow the issue-tagged convention. No open PR titles were present during audit. |
+
+## Applied Local Changes
+
+- Added this Bootstrap 1.3.0 realignment audit.
+- Planned local updates:
+  - Refresh `.github/LABELS.md` release-label wording and reserved-label colors.
+  - Remove stale removed-skill wording from `docs/file-structure.md`.
+  - Refresh `RELEASING.md` release-flow guidance from the Bootstrap 1.3.0 Patina Project supplement.
+  - Refresh `.github/workflows/release.yml` trigger comment/order to match the Bootstrap 1.3.0 Patina Project supplement.
+
+## Remaining Follow-Ups
+
+- Remote labels `autorelease: pending` and `autorelease: tagged` exist with
+  color `ededed`, but both have empty descriptions. Bootstrap 1.3.0 reserves
+  these labels for Release Please automation and requires non-empty
+  descriptions. The `bootstrap` contract says not to mutate labels without
+  explicit confirmation, so this branch documents the gap instead of editing
+  the remote labels.
+- Release immutability is UI-only in GitHub's standard repository API and was
+  not verified by CLI. Confirm **Settings -> General -> Releases -> Enable
+  release immutability** by eye.
+- End-to-end release smoke was not run because this branch should not cut or
+  simulate a release. Existing release workflow configuration and repository
+  permissions were audited instead.
+
+## Verification
+
+- `find . -maxdepth 3 ...` confirmed required baseline files and agent-plugin
+  surfaces are present.
+- `gh repo view --json nameWithOwner,visibility,defaultBranchRef` returned
+  `patinaproject/using-github`, `PUBLIC`, default branch `main`.
+- `gh api repos/:owner/:repo --jq '{allow_squash_merge, allow_merge_commit, allow_rebase_merge, squash_merge_commit_title, squash_merge_commit_message, delete_branch_on_merge, allow_update_branch}'` returned the expected Bootstrap merge settings.
+- `gh api repos/:owner/:repo/actions/permissions/workflow --jq .default_workflow_permissions` returned `write`.
+- `gh api repos/:owner/:repo/rulesets --jq '.[] | select(.target=="tag")'` returned no tag rulesets.
+- `gh label list --json name,color,description --jq '.'` showed the reserved release labels are present, but their descriptions are empty.

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -16,8 +16,7 @@ Contributor reference for the repository layout. For user-facing install and usa
 
 Each skill lives in its own directory under `skills/` with `SKILL.md` as the main contract.
 `skills/using-github/` is the umbrella GitHub behavior skill. The other skill
-directories are specialized workflows that it routes to for issue filing,
-issue editing, branch setup, and changelog writing.
+workflow contracts are adjacent documentation inside the same skill package.
 
 ## Docs
 

--- a/docs/superpowers/plans/2026-04-27-26-realign-repo-to-bootstrap-1-3-0-plan.md
+++ b/docs/superpowers/plans/2026-04-27-26-realign-repo-to-bootstrap-1-3-0-plan.md
@@ -1,0 +1,216 @@
+# Realign Repo To Bootstrap 1.3.0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Audit and realign `patinaproject/using-github` with the Bootstrap 1.3.0 baseline.
+
+**Architecture:** Treat Bootstrap 1.3.0 as the baseline contract and this repository's `AGENTS.md` as the local authority. Apply safe local file updates directly, record confirmation-gated remote or release-setting changes as documented gaps, and preserve the existing `using-github` skill behavior.
+
+**Tech Stack:** Markdown skills and docs, JSON plugin manifests, PNPM, Husky, markdownlint-cli2, commitlint, GitHub CLI, GitHub Actions YAML.
+
+---
+
+## Task 1: Audit Bootstrap 1.3.0 Baseline Drift
+
+**Files:**
+
+- Read: `/Users/tlmader/.codex/plugins/cache/patinaproject-skills/bootstrap/1.3.0/skills/bootstrap/audit-checklist.md`
+- Read: `AGENTS.md`
+- Read: `.github/LABELS.md`
+- Read: `.github/workflows/*.yml`
+- Create: `docs/bootstrap-1.3.0-realignment-audit.md`
+
+- [ ] **Step 1: Run the local baseline inventory**
+
+  Run:
+
+  ```bash
+  find . -maxdepth 3 -type f \( -path './.claude-plugin/*' -o -path './.codex-plugin/*' -o -path './.cursor/*' -o -path './.github/*' -o -path './scripts/*' -o -name 'package.json' -o -name 'AGENTS.md' -o -name 'CLAUDE.md' -o -name 'README.md' -o -name 'RELEASING.md' -o -name 'CONTRIBUTING.md' -o -name 'SECURITY.md' -o -name '.markdownlint.jsonc' -o -name '.markdownlintignore' -o -name '.nvmrc' -o -name '.editorconfig' -o -name '.gitattributes' -o -name '.gitignore' -o -name 'release-please-config.json' -o -name '.release-please-manifest.json' -o -name '.windsurfrules' \) -print | sort
+  ```
+
+  Expected: output includes every required Bootstrap core file and agent-plugin surface, or the missing file becomes an audit gap.
+
+- [ ] **Step 2: Run remote baseline probes**
+
+  Run:
+
+  ```bash
+  gh repo view --json nameWithOwner,visibility,defaultBranchRef
+  gh api repos/:owner/:repo --jq '{allow_squash_merge, allow_merge_commit, allow_rebase_merge, squash_merge_commit_title, squash_merge_commit_message, delete_branch_on_merge, allow_update_branch}'
+  gh api repos/:owner/:repo/actions/permissions/workflow --jq .default_workflow_permissions
+  gh api repos/:owner/:repo/rulesets --jq '.[] | select(.target=="tag")'
+  gh label list --json name,color,description --jq '.'
+  ```
+
+  Expected: repository metadata resolves; permission or settings drift is recorded rather than silently changed.
+
+- [ ] **Step 3: Write the audit report**
+
+  Create `docs/bootstrap-1.3.0-realignment-audit.md` with:
+
+  ```markdown
+  # Bootstrap 1.3.0 Realignment Audit
+
+  ## Summary
+
+  Short summary of whether the repo is aligned, partially aligned, or blocked.
+
+  ## Applied Local Changes
+
+  - List every local baseline change applied by this branch.
+
+  ## Remaining Follow-Ups
+
+  - List remote settings, labels, or release checks that need operator confirmation.
+
+  ## Verification
+
+  - List every validation command and result.
+  ```
+
+- [ ] **Step 4: Commit the audit report**
+
+  Run:
+
+  ```bash
+  git add docs/bootstrap-1.3.0-realignment-audit.md
+  git commit -m "docs: #26 add bootstrap realignment audit"
+  ```
+
+## Task 2: Apply Safe Local Baseline Updates
+
+**Files:**
+
+- Modify: `.github/LABELS.md` if reserved release label documentation is stale
+- Modify: `.github/workflows/release.yml` if Bootstrap 1.3.0 workflow permissions are missing
+- Modify: `AGENTS.md`, `README.md`, `RELEASING.md`, or `docs/file-structure.md` only when the audit finds stale Bootstrap 1.3.0 guidance
+- Modify: `docs/bootstrap-1.3.0-realignment-audit.md`
+
+- [ ] **Step 1: Inspect candidate local gaps**
+
+  Run targeted checks from the audit report:
+
+  ```bash
+  rg 'autorelease: pending|autorelease: tagged' .github/LABELS.md AGENTS.md
+  rg 'permissions:' .github/workflows/release.yml .github/workflows/lint-actions.yml .github/workflows/lint-md.yml .github/workflows/lint-pr.yml
+  pnpm check:versions
+  ```
+
+  Expected: version checks pass; any local docs or workflow gaps are clear enough to patch.
+
+- [ ] **Step 2: Patch only local baseline drift**
+
+  Update local files only when the Bootstrap 1.3.0 expectation is unambiguous and does not replace repository-specific `using-github` behavior. Do not mutate GitHub repository settings or labels from this task; record those as follow-ups in the audit report.
+
+- [ ] **Step 3: Verify local references**
+
+  Run:
+
+  ```bash
+  rg 'Bootstrap 1.3.0|autorelease: pending|permissions:' AGENTS.md README.md RELEASING.md .github docs
+  pnpm lint:md
+  pnpm check:versions
+  ```
+
+  Expected: Markdown and version checks pass; references are intentional.
+
+- [ ] **Step 4: Commit local realignment updates**
+
+  Run:
+
+  ```bash
+  git add .github AGENTS.md README.md RELEASING.md docs/file-structure.md docs/bootstrap-1.3.0-realignment-audit.md
+  git commit -m "chore: #26 realign bootstrap baseline files"
+  ```
+
+## Task 3: Run Bootstrap Verification Self-Test
+
+**Files:**
+
+- Modify: `docs/bootstrap-1.3.0-realignment-audit.md`
+
+- [ ] **Step 1: Run Bootstrap self-test commands**
+
+  Run:
+
+  ```bash
+  pnpm install
+  pnpm exec commitlint --help
+  pnpm lint:md
+  bash -lc 'echo "feat: bad" | pnpm exec commitlint; test $? -ne 0'
+  bash -lc 'echo "feat: #1 ok" | pnpm exec commitlint'
+  ```
+
+  Expected: install, help, lint, and valid commitlint sample pass; the invalid commitlint sample exits non-zero and the wrapper exits zero.
+
+- [ ] **Step 2: Run targeted Bootstrap probes**
+
+  Run:
+
+  ```bash
+  pnpm check:versions
+  find skills -maxdepth 2 -name SKILL.md -print
+  rg 'uses: [^#@]*@[A-Za-z0-9_.-]+$' .github/workflows || true
+  gh api repos/:owner/:repo/actions/permissions/workflow --jq .default_workflow_permissions
+  ```
+
+  Expected: manifests match package version; only intended skills ship; workflow action references remain SHA-pinned; workflow permissions result is recorded.
+
+- [ ] **Step 3: Update audit verification section**
+
+  Record each command outcome in `docs/bootstrap-1.3.0-realignment-audit.md`, including any remote follow-up that still requires operator confirmation.
+
+- [ ] **Step 4: Commit verification notes**
+
+  Run:
+
+  ```bash
+  git add docs/bootstrap-1.3.0-realignment-audit.md
+  git commit -m "test: #26 record bootstrap verification"
+  ```
+
+## Task 4: Local Review And Publish
+
+**Files:**
+
+- Read: `.github/pull_request_template.md`
+- Create: `/tmp/using-github-26-pr-body.md`
+
+- [ ] **Step 1: Run local review**
+
+  Review the diff for accidental changes to `skills/using-github/SKILL.md`, plugin version drift, unpinned actions, and undocumented Bootstrap gaps.
+
+- [ ] **Step 2: Push branch**
+
+  Run:
+
+  ```bash
+  git push -u origin 26-realign-repo-to-bootstrap-1-3-0
+  ```
+
+- [ ] **Step 3: Create PR**
+
+  Render `/tmp/using-github-26-pr-body.md` using `.github/pull_request_template.md` headings in order, include `Closes #26`, and add one `### AC-26-n` subsection per acceptance criterion with verification notes.
+
+  Run:
+
+  ```bash
+  gh pr create --title "chore: #26 realign repo to bootstrap 1.3.0" --body-file /tmp/using-github-26-pr-body.md
+  ```
+
+- [ ] **Step 4: Check publish state**
+
+  Run:
+
+  ```bash
+  gh pr view --json number,url,headRefName,mergeStateStatus,reviewDecision,statusCheckRollup
+  gh pr checks --watch --interval 10
+  ```
+
+  Expected: PR exists and required checks either pass or any pending/failing state is triaged before handoff.
+
+## Self-Review
+
+- Spec coverage: Task 1 covers AC-26-1; Task 2 covers AC-26-2; Task 3 covers AC-26-3; Task 4 covers the Superteam publish requirement.
+- Placeholder scan: no placeholders remain; each task has exact paths, commands, and expected outcomes.
+- Scope check: the plan stays within Bootstrap 1.3.0 realignment and explicitly avoids redesigning `using-github` workflow behavior.

--- a/docs/superpowers/specs/2026-04-27-26-realign-repo-to-bootstrap-1-3-0-design.md
+++ b/docs/superpowers/specs/2026-04-27-26-realign-repo-to-bootstrap-1-3-0-design.md
@@ -1,0 +1,67 @@
+# Design: Realign repo to Bootstrap 1.3.0 [#26](https://github.com/patinaproject/using-github/issues/26)
+
+## Intent
+
+Realign `patinaproject/using-github` with the Bootstrap 1.3.0 baseline while
+preserving the repository-specific GitHub workflow skill behavior that makes
+this repo distinct. The work should produce a concrete audit, apply accepted
+baseline updates, and document any intentionally deferred or out-of-scope gaps.
+
+## Requirements
+
+- AC-26-1: Given the current repository state, when it is compared with
+  Bootstrap 1.3.0, then any required baseline differences are identified and
+  either applied or documented as intentionally out of scope.
+- AC-26-2: Given baseline updates are needed, when the realignment is
+  implemented, then Markdown, GitHub templates, plugin metadata, and local
+  tooling conventions remain consistent with repository guidance.
+- AC-26-3: Given the work is complete, when validation runs, then the
+  documented Markdown and repository checks pass or any remaining gaps are
+  clearly noted.
+
+## Approach
+
+Use Bootstrap 1.3.0 realignment mode as the source of truth for baseline
+coverage. The Executor will walk the audit checklist in ordered batches:
+plugin manifests, commit and PR conventions, PNPM tooling, agent and repo docs,
+AI platform surfaces, workflows, Superpowers scaffolding, repository settings,
+labels, and sampled title hygiene.
+
+For each local file gap, the Executor will compare the repository file against
+the Bootstrap 1.3.0 template or checklist expectation, classify the gap as
+missing, stale, or divergent, and apply the conservative baseline update when
+it does not overwrite repository-specific behavior. If a recommended change is
+not safe to apply automatically, the Executor will document the gap and the
+reason instead of forcing it through.
+
+Remote settings and label checks will be audited through `gh` where available.
+Repository settings writes and reserved release-label edits require explicit
+operator confirmation under the Bootstrap contract, so the implementation may
+report those as follow-up actions rather than mutating them unilaterally.
+
+## Boundaries
+
+This issue covers baseline realignment only. It does not redesign the
+`using-github` workflow model, rename the repository, change issue or PR
+semantics beyond the Bootstrap 1.3.0 baseline, or cut a release.
+
+## Verification
+
+Validation should include the Bootstrap self-test where applicable:
+
+- `pnpm install`
+- `pnpm exec commitlint --help`
+- `pnpm lint:md`
+- `echo "feat: bad" | pnpm exec commitlint`
+- `echo "feat: #1 ok" | pnpm exec commitlint`
+
+Additional targeted checks should verify plugin version lockstep, Markdown
+template references, GitHub Actions pinning, release workflow permissions, and
+any applied Bootstrap audit recommendations.
+
+## Concerns
+
+No approval-relevant concerns remain. The only expected constraint is that
+Bootstrap realignment mode forbids unconfirmed remote or destructive rewrites;
+those items should be reported as explicit follow-up gaps when confirmation is
+needed.


### PR DESCRIPTION
## Summary

- Added a Bootstrap 1.3.0 realignment audit for `patinaproject/using-github`.
- Refreshed local baseline docs for release labels, release flow, workflow trigger wording, and current skill layout.
- Documented remaining confirmation-gated follow-ups for remote release labels, release immutability, and release smoke.

## Linked issue

- Closes #26

## Acceptance criteria

### AC-26-1

Bootstrap 1.3.0 differences were audited and either applied locally or documented as follow-ups.

- [x] Bootstrap audit evidence — Codex | local worktree | @tlmader | 2026-04-27T15:43:36Z
- [ ] Manual test: 1. Review `docs/bootstrap-1.3.0-realignment-audit.md`. 2. Confirm remaining follow-ups are acceptable for this PR.

### AC-26-2

Safe local baseline updates preserve repository guidance across Markdown, GitHub metadata, workflows, and plugin tooling.

- [x] Local baseline evidence — Codex | local worktree | @tlmader | 2026-04-27T15:43:36Z
- [ ] Manual test: 1. Review `.github/LABELS.md`, `.github/workflows/release.yml`, `RELEASING.md`, and `docs/file-structure.md`. 2. Confirm the changes match Bootstrap 1.3.0 without changing `using-github` behavior.

### AC-26-3

Bootstrap validation passed locally and any remaining gaps are clearly noted in the audit.

- [x] Validation evidence — Codex | local worktree | @tlmader | 2026-04-27T15:43:36Z
- [ ] Manual test: 1. Review the `Verification` section in `docs/bootstrap-1.3.0-realignment-audit.md`. 2. Confirm the recorded command results and follow-up gaps are sufficient.

## Validation

- `pnpm install`
- `pnpm exec commitlint --help`
- `pnpm lint:md`
- `bash -lc 'echo "feat: bad" | pnpm exec commitlint; test $? -ne 0'`
- `bash -lc 'echo "feat: #1 ok" | pnpm exec commitlint'`
- `pnpm check:versions`
- `find skills -maxdepth 2 -name SKILL.md -print`
- `rg 'uses: [^#@]*@[A-Za-z0-9_.-]+$' .github/workflows || true`
- `gh api repos/:owner/:repo/actions/permissions/workflow --jq .default_workflow_permissions`
- `git diff --check origin/main..HEAD`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts "ok #{f}" }'`

## Docs updated

- [x] Updated in this PR
