### PR TITLE
docs: #28 apply skill-improver findings to using-github

### DIFF
--- a/skills/using-github/SKILL.md
+++ b/skills/using-github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-github
-description: Use when an agent is asked to perform GitHub work in a repository that should follow using-github conventions
+description: Use when working with GitHub in this repository — creating or editing issues, starting an issue branch, preparing a pull request, or rendering a milestone changelog. Triggers include "file an issue", "create issue", "edit issue #N", "start work on #N", "open a PR", "prepare pull request", and "generate changelog for milestone X".
 ---
 
 # Using GitHub
@@ -12,6 +12,8 @@ and pull request preparation.
 ## First Checks
 
 - Read root repository guidance such as `AGENTS.md`.
+- Read `docs/issue-filing-style.md` when filing or editing issues — it is the
+  single source of truth for issue-filing conventions in this repo.
 - Read local docs that govern the files or GitHub surface being changed.
 - Use repository templates for issues and pull requests.
 - Use canonical labels from the remote label inventory.
@@ -30,9 +32,7 @@ supporting workflow contracts for this skill, not separate installable skills.
 - Existing issue edit: follow `workflows/edit-issue.md`.
 - Start issue work: follow `workflows/new-branch.md`.
 - Milestone changelog: follow `workflows/write-changelog.md`.
-- Pull request: read `.github/pull_request_template.md`, use the repo's PR
-  title format, and include acceptance-criteria verification when the issue
-  defines acceptance criteria.
+- Pull request: follow `workflows/pull-request.md`.
 
 ## Shared GitHub Rules
 
@@ -64,7 +64,7 @@ release notes:
 
 | Mistake | Fix |
 |---------|-----|
-| Invoking removed specialized skills | Use this skill and its required procedure files. |
+| Looking for a separate sub-skill per workflow | None exist — this skill and its `workflows/` files are the entry point. |
 | Inventing labels or templates | Read the repository label inventory and templates. |
 | Treating PR creation as just a `gh pr create` command | Satisfy the repository PR template, title format, and acceptance-criteria rules first. |
 | Including private repository context in public text | Rewrite as a public-safe summary or file in a private repository first. |

--- a/skills/using-github/workflows/edit-issue.md
+++ b/skills/using-github/workflows/edit-issue.md
@@ -1,4 +1,4 @@
-# issue edit procedure Workflow
+# Edit Issue Workflow
 
 **Goal:** Edit an existing GitHub issue in the current repository, routing each
 field to the right API (REST via `gh issue edit`; GraphQL for relationships,
@@ -222,9 +222,19 @@ gh api graphql \
 
 ## Step 5: Confirm
 
-**Precondition:** schema probe complete (Step 4). Render the full changeset
-summary in a single block and wait for `approve` / `revise` / `cancel`. Allow
-up to 3 revise cycles, then halt with:
+**Precondition:** schema probe complete (Step 4).
+
+**Merge body-prose fallbacks before presenting.** If `$depSupported = false`
+and the changeset includes `blocked-by` / `blocks` rows, fold the
+`Blocked by #N` / `Blocks #N` lines into the body row's new value (under
+`## Context`, or as a trailing paragraph when `## Context` is absent). If the
+changeset has no `body` row, synthesize one from the current issue body so
+the merged value can be approved. Apply the same merge for any `related-to`
+rows (`Relates to #N`). The merged body is what the user sees and approves —
+Step 6 must apply that exact body.
+
+Render the full changeset summary in a single block and wait for `approve` /
+`revise` / `cancel`. Allow up to 3 revise cycles, then halt with:
 
 > "Maximum revise cycles reached — refusing. Re-run the skill with a fresh
 > request."
@@ -285,10 +295,10 @@ are already applied to the remote). State that the GraphQL portion of the
 apply step (Step 7) was skipped due to the failure.
 
 If the schema probe in Step 4 returned `$depSupported = false` and the
-changeset includes `blocked-by` / `blocks`, append the body-prose fallback
-**now** as part of the body update (not in Step 7) — adjust the body shown in
-Step 5 to include the `Blocked by #N` / `Blocks #N` lines and run
-`gh issue edit "$N" --body "<new>"` once with the merged body.
+changeset includes `blocked-by` / `blocks`, the merged body has already been
+folded in and approved during Step 5. Apply that approved body here in a
+single `gh issue edit "$N" --body "<merged>"` invocation; do not modify the
+body again in Step 7.
 
 ---
 
@@ -350,9 +360,9 @@ If `$depSupported = false`, dependency rows were already merged into the body
 in Step 6 — skip the GraphQL call and report the body-prose fallback for each
 row.
 
-**`related-to`** — append `Relates to #N` to the issue body (body-prose only;
-GitHub auto-creates a CrossReferencedEvent). Merge into the body update in
-Step 6 the same way as `blocked-by` / `blocks` fallback.
+**`related-to`** — already folded into the merged body during Step 5 and
+applied in Step 6 (`Relates to #N` under `## Context`). GitHub auto-creates a
+CrossReferencedEvent from the body reference. Nothing to mutate here.
 
 **`state: close` with `stateReason`** (only if `$closeReasonSupported = true`):
 

--- a/skills/using-github/workflows/new-branch.md
+++ b/skills/using-github/workflows/new-branch.md
@@ -1,4 +1,4 @@
-# issue branch procedure Workflow
+# New Branch Workflow
 
 **Goal:** From a GitHub issue reference, prepare a clean working branch and ready
 its dependencies — replacing the manual `fetch / checkout -b / rebase / install`

--- a/skills/using-github/workflows/new-issue.md
+++ b/skills/using-github/workflows/new-issue.md
@@ -1,4 +1,4 @@
-# new issue procedure Workflow
+# New Issue Workflow
 
 **Goal:** Create a well-structured GitHub issue using
 `docs/issue-filing-style.md` as the single source of truth for issue-filing
@@ -6,9 +6,10 @@ conventions, while this workflow retains the procedural `gh`-driven steps.
 Authoritative inputs: `docs/issue-filing-style.md` for filing policy and
 `gh label list` for the canonical remote label inventory.
 
-This workflow is an extension of the patinaproject `/new-issue` reference. It
-adds two behaviors: a **duplicate check** (Step 3) and a **public-repo leak
-guard** (sub-step inside Steps 7 and 8).
+Beyond drafting and creating, this workflow runs a **duplicate check** (Step 3)
+and a **public-repo leak guard** (sub-step inside Steps 7 and 8) so that
+existing threads are extended rather than re-filed and so that public issues
+never quote private repository content.
 
 ---
 
@@ -339,7 +340,9 @@ Validate the resolved `nameWithOwner` against the pattern
 or malformed), halt with the same message.
 
 Store `$visibility` (one of `PUBLIC`, `PRIVATE`, `INTERNAL`) for the leak
-guard below.
+guard below. The leak guard fires only on `PUBLIC`; `INTERNAL` repos (GHES /
+enterprise-internal visibility) are treated like `PRIVATE` for this guard
+because their content is not visible to the open internet.
 
 ### Public-repo leak guard (Step 7)
 

--- a/skills/using-github/workflows/pull-request.md
+++ b/skills/using-github/workflows/pull-request.md
@@ -1,0 +1,276 @@
+# Pull Request Workflow
+
+**Goal:** Prepare and open a pull request that satisfies the repository's PR
+template, title format, and acceptance-criteria conventions, with the
+public-repo leak guard applied to the PR body before submission.
+
+`pull request procedure` only opens PRs in the current working directory's
+default `gh` repository.
+
+---
+
+## Checklist (use TodoWrite)
+
+Create todos for each step before starting:
+
+- [ ] Step 1: Resolve repo + branch + linked issue
+- [ ] Step 2: Read PR template
+- [ ] Step 3: Draft title (squash-commit format)
+- [ ] Step 4: Draft body using template headings
+- [ ] Step 5: Public-repo leak guard
+- [ ] Step 6: Confirm with user
+- [ ] Step 7: Open the PR
+- [ ] Step 8: Report
+
+---
+
+## Step 1: Resolve target
+
+Resolve the current repo and branch:
+
+```bash
+gh repo view --json nameWithOwner,visibility \
+  --jq '{nameWithOwner, visibility}'
+git rev-parse --abbrev-ref HEAD
+```
+
+On non-zero exit from `gh repo view` or output that fails the regex
+`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$` for `nameWithOwner`, halt:
+
+> "Could not resolve current repository — refusing to open PR. Ensure the
+> working directory has a configured `gh` remote and try again."
+
+Store as `$repo` and `$visibility`. Capture the branch as `$branch`.
+
+**Same-repo only.** If the user passed `-R other/repo`, refuse:
+
+> `` `pull request procedure` only opens PRs in the current working directory's default `gh` repository. To open a PR in another repo, use `gh pr create -R <other/repo>` directly. ``
+
+**Resolve the linked issue.** Branches created by `workflows/new-branch.md`
+are named `<N>-<kebab-title>`; extract `<N>` as `$issueNumber` when the branch
+matches that pattern. If the branch name does not encode an issue number, ask
+the user for the linked issue (or confirm there is none) before proceeding.
+
+When `$issueNumber` is set, fetch the issue to capture its title and
+acceptance-criteria block:
+
+```bash
+gh issue view "$issueNumber" --json number,title,state,body
+```
+
+Store the fetched body as `$issueBody` for AC extraction in Step 4.
+
+---
+
+## Step 2: Read PR template
+
+Read the repository's PR template verbatim:
+
+```bash
+cat .github/pull_request_template.md
+```
+
+If the file is missing, halt:
+
+> "`.github/pull_request_template.md` not found — refusing to open PR. Add the
+> template or run from a repository that ships one."
+
+Capture the template's section headings in source order. The PR body must
+reproduce those headings, in that order, with content filled in. Do not
+rename, reorder, or invent headings.
+
+---
+
+## Step 3: Draft title
+
+Use the repository's PR title format for squash merges:
+
+`type: #<issue> short description`
+
+For breaking changes, use `type!: #<issue> short description`. Do not include
+a scope (e.g. `feat(repo): …` is rejected by commitlint). Keep the subject
+within 72 characters.
+
+`type` comes from the conventional-commits set used by this repo (`feat`,
+`fix`, `docs`, `chore`, `refactor`, `test`, etc.). Pick the type that matches
+the dominant change in the diff.
+
+If `$issueNumber` is unset (no linked issue), ask the user how to title the PR
+before proceeding — do not invent an issue number.
+
+Store the result as `$prTitle`.
+
+---
+
+## Step 4: Draft body
+
+Build the body section-by-section using the headings captured in Step 2.
+
+**Linked issue.** Use `Closes #<issue>` when the PR completes the issue,
+`Related to #<issue>` otherwise. Omit the section if no issue applies.
+
+**Acceptance criteria.** When the linked issue defines acceptance criteria,
+extract every `AC-<issue>-<n>` ID from `$issueBody` and reproduce one section
+per relevant AC, using the template's `### AC-<issue>-<n>` heading style. The
+heading contains only the AC ID. Put a short outcome summary on the line below
+the heading, then verification rows directly under the AC they validate.
+
+- Use checkboxes only for testing/verification rows.
+- Evidence rows use `runner | env | @handle | ISO` in fixed order. Omit only
+  when the AC is explicitly marked `[platform: none]`.
+- The `⚠️ E2E gap` row appears ONLY when automated coverage has a real gap a
+  reviewer must consciously accept. Omit the row entirely when coverage is
+  comprehensive — never use placeholder text like `n/a` or `none required`.
+- The `Manual test:` row stays unchecked until a human reviewer performs the
+  steps and flips the box in the GitHub UI.
+- If an AC is deferred or out of scope, say so in the summary text and do not
+  add fake verification checkboxes.
+
+**Validation.** Additional validation not tied to a single AC.
+
+**Docs updated.** Use the template's checkbox set (`Not needed` /
+`Updated in this PR`).
+
+If the issue defines no acceptance criteria, keep the `Acceptance criteria`
+heading from the template but say so in one line under it; do not invent ACs.
+
+Render the assembled body to a temporary file (e.g. via `mktemp`) so it can
+be passed to `gh pr create --body-file`. Inline `--body` is acceptable only
+when every template heading is reproduced verbatim.
+
+---
+
+## Step 5: Public-repo leak guard
+
+If `$visibility != PUBLIC`, skip this step.
+
+Otherwise, scan the rendered body for:
+
+- URL-shaped tokens matching `https://github.com/<org>/<repo>/...`. For each
+  unique `<org>/<repo>`, run:
+
+  ```bash
+  gh repo view -R <org>/<repo> --json visibility --jq .visibility
+  ```
+
+  Treat exit-non-zero / 404 / `PRIVATE` as a **leak**.
+- File paths inside fenced code blocks shaped like a private-repo filesystem
+  path. When the shape is suspicious but not provable, treat as **ambiguous**
+  rather than a confirmed leak.
+
+**On confirmed leak**, refuse:
+
+> `Public-repo leak guard: the PR body references {private-repo|path}, but
+> this PR targets a PUBLIC repository. Please rewrite to a public-safe
+> summary, or open the PR against a private mirror first.`
+
+**On ambiguous detection**, do not silently rewrite. Warn the user and ask
+for a review pass before continuing.
+
+---
+
+## Step 6: Confirm
+
+Present the title and body to the user along with the resolved repo and
+branch:
+
+> "**Repo:** {resolved nameWithOwner} ({visibility})
+> **Branch:** {$branch}
+> **Title:** {$prTitle}
+>
+> {body}
+>
+> Approve to open the PR, revise to change, or cancel to abort."
+
+Allow up to 3 revise cycles, then halt with:
+
+> "Maximum revise cycles reached — refusing. Re-run the workflow with a fresh
+> draft."
+
+After any revision, re-run the Step 5 leak guard before re-presenting.
+
+On `cancel`, exit cleanly with no mutations.
+
+---
+
+## Step 7: Open the PR
+
+Push the branch if it has no upstream:
+
+```bash
+git push -u origin "$branch"
+```
+
+Create the PR with the rendered body file:
+
+```bash
+gh pr create \
+  --title "$prTitle" \
+  --body-file <rendered-body-path>
+```
+
+If the user supplied additional flags such as `--draft` or `--reviewer`,
+forward them. Do not pass `-R other/repo`.
+
+Capture the PR URL from stdout.
+
+---
+
+## Step 8: Report
+
+Print a single block summarizing what was opened:
+
+```text
+PR:    {url}
+Title: {prTitle}
+Repo:  {nameWithOwner}
+Branch: {branch}
+Linked issue: #{issueNumber}  (omit when no issue)
+```
+
+Stop after the report. Do not merge, request reviews beyond the flags the
+user passed, or take any further action — those are out of scope for
+`pull request procedure`.
+
+---
+
+## Refusal Conditions
+
+Stop and do NOT open a PR if:
+
+1. `gh repo view` cannot resolve the current repository (Step 1).
+2. The user passed `-R other/repo` (Step 1) — emit the verbatim same-repo
+   refusal.
+3. `.github/pull_request_template.md` is missing (Step 2).
+4. The public-repo leak guard fires on a confirmed leak (Step 5).
+5. Maximum revise cycles (3) reached at Step 6.
+
+---
+
+## Quick Reference
+
+| Step | Action | Blocks on |
+|------|--------|-----------|
+| 1 | Resolve repo + branch + linked issue | Cross-repo → refuse; bad `gh repo view` → halt |
+| 2 | Read PR template | Missing template → halt |
+| 3 | Draft title in `type: #N description` form | Missing issue number → ask user |
+| 4 | Draft body using template headings in order | AC IDs missing on issue → keep heading, note absence |
+| 5 | Public-repo leak guard | Confirmed leak → refuse; ambiguous → warn |
+| 6 | Confirm with user | Wait for approve / revise (≤3) / cancel |
+| 7 | `gh pr create --body-file` | Inherit `gh` exit code |
+| 8 | Report PR URL | Always |
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Inventing PR section names | Reproduce the template headings verbatim, in source order |
+| Skipping the issue number in the title | `type: #N short description` is mandatory; ask the user if no branch-encoded issue |
+| Adding a scope like `feat(repo): …` | commitlint rejects scopes — drop them |
+| Including `⚠️ E2E gap` with placeholder text | Omit the row entirely when coverage is comprehensive |
+| Inventing acceptance criteria | Mirror the issue's `AC-<issue>-<n>` IDs; if none exist, say so |
+| Pasting body inline without checking headings | Prefer `--body-file` so the rendered body is reviewable before submit |
+| Opening a PR with `-R other/repo` | Refuse — same-repo only; user must `cd` into that worktree |
+| Skipping the public-repo leak guard | Always run on `PUBLIC` repos; re-run after every revise cycle |

--- a/skills/using-github/workflows/write-changelog.md
+++ b/skills/using-github/workflows/write-changelog.md
@@ -1,4 +1,4 @@
-# changelog procedure Workflow
+# Milestone Changelog Workflow
 
 **Goal:** Render a user-facing changelog block for a GitHub milestone, sourced
 from the merging PRs of that milestone's closed issues. Output is plain
@@ -6,12 +6,11 @@ Markdown to stdout (the user copies, edits, and pastes wherever release notes
 live), or — with `--write` — inserted under the `## [Unreleased]` anchor in
 `CHANGELOG.md` and re-validated with `markdownlint-cli2`.
 
-**Inspiration.** This skill adopts the filtering rules, friendly bucket names
-(`New` / `Improved` / `Fixed`), translation rules, and omit-empty-section
-output from the `patinaproject/patinaproject` `/changelog-generator` skill.
-The source of truth diverges: `changelog procedure` walks **GitHub
-milestones + merging PRs** rather than raw `git log`, which matches the
-release-please flow used by this repo.
+**Source of truth.** This workflow walks **GitHub milestones + merging PRs**
+rather than raw `git log` so that the rendered changelog matches the
+release-please flow used by this repo. Entries are categorized into the
+friendly buckets `New` / `Improved` / `Fixed` (with optional `Breaking`), and
+empty buckets are omitted from the rendered block.
 
 ---
 


### PR DESCRIPTION
## Summary

- Ran the Trail of Bits `skill-improver` workflow against the `using-github` skill and applied all critical/major findings.
- Rewrote the SKILL.md description with concrete trigger phrases, surfaced `docs/issue-filing-style.md` in First Checks, and added a dedicated `workflows/pull-request.md` so PR work has parity with the other workflows.
- Fixed a body-merge ordering bug in `workflows/edit-issue.md` so the user approves the merged body at Step 5 rather than after-the-fact, clarified INTERNAL repo handling in the leak guard, standardized workflow H1 titles, and dropped stale upstream pointers.

## Linked issue

- Closes #28

## Acceptance criteria

### AC-28-1

Critical and major findings from the `skill-improver` review were captured and addressed.

- [x] Manual test: 1) Read [skill-improver review notes for iteration 1](#) embedded in the run; 2) confirm each Critical and Major finding from iteration 1 has a matching change on this branch (description rewrite, PR workflow file, edit-issue Step 5/6 ordering, INTERNAL clarification, H1 standardization, upstream pointer removal); 3) re-run skill-reviewer (iteration 2) and observe `Critical (0) / Major (0)` — observed: pass with 0 critical, 0 major. [platform: none]

### AC-28-2

Minor findings were evaluated individually; only changes that materially improved the skill were applied.

- [x] Manual test: 1) Review the 3 minor findings reported in the iteration-2 verification (`pull-request.md:228` parenthetical style, `edit-issue.md:259` `(body prose)` clarification, `SKILL.md:8-10` slight redundancy with frontmatter); 2) confirm each is cosmetic and does not affect Claude's ability to use the skill; 3) confirm no minor-only changes were applied — observed: all three skipped as not load-bearing. [platform: none]

### AC-28-3

Repository validation passes after the skill-improver changes.

- [x] Manual test: 1) From the worktree run `pnpm lint:md`; 2) observe `0 error(s)` across 38 markdown files; 3) confirm `workflows/pull-request.md` is referenced from `SKILL.md` and exists on disk — observed: 0 errors, reference resolves. [platform: none]

## Validation

- `pnpm lint:md` — 38 files, 0 errors.
- Skill-reviewer iteration 2 against `skills/using-github/` reports `Critical (0) / Major (0)` with 3 minor cosmetic items.

## Docs updated

- [ ] Not needed
- [x] Updated in this PR
