### PR TITLE
docs: #25 document H2-min rule for GitHub auto-TOC sidebar

### DIFF
--- a/docs/issue-filing-style.md
+++ b/docs/issue-filing-style.md
@@ -46,6 +46,40 @@ What this issue explicitly does NOT cover.
 
 Keep `## Out of Scope` present even when brief. Do not invent unlisted sections — if you need additional structure, extend an existing section instead.
 
+## Heading levels for navigability
+
+GitHub renders an auto-generated **Table of contents** sidebar widget on
+issues, PRs, and discussions. The widget surfaces only top-level headings
+(`#` and `##`). Headings at `###` and deeper still resolve when linked
+manually, but they are hidden from the sidebar.
+
+Apply this rule when authoring any long issue body, PR description, or
+discussion post:
+
+- **Default to `##`** for every section a reader might jump to from the
+  sidebar. The five-section body template above already follows this rule.
+- **Reserve `###` for tightly-coupled sub-sections** under a single parent
+  — for example, the per-AC `### AC-<issue>-<n>` rows under
+  `## Acceptance criteria` in the PR template. Promoting every sub-row to
+  `##` would clutter the sidebar.
+- A manual in-body Markdown TOC (a `## Table of contents` bullet list with
+  anchor links) does resolve `###` and deeper anchors, but readers using
+  the sidebar will not see those sections. If a sub-section is important
+  enough to deep-link, also promote it to `##`.
+
+### GitHub anchor algorithm
+
+When you build anchors by hand for a manual in-body TOC, GitHub derives
+the anchor from the heading text as follows:
+
+1. Lowercase the text.
+2. Replace each space with `-`.
+3. Strip every character that is not alphanumeric, `-`, or `_`.
+4. Collapse runs of `-` into a single `-`.
+
+Example: `## Per-provider operator checklist` →
+`#per-provider-operator-checklist`.
+
 ## Acceptance Criteria format
 
 - IDs follow the pattern `AC-<issue-number>-<integer>`, for example `AC-1-1`, `AC-1-2`.

--- a/skills/using-github/SKILL.md
+++ b/skills/using-github/SKILL.md
@@ -48,6 +48,9 @@ supporting workflow contracts for this skill, not separate installable skills.
 - Duplicate checks happen before filing new issues.
 - Label choices come from `gh label list`; do not invent labels.
 - Pull request bodies use the repository template headings in order.
+- Long issue, PR, and discussion descriptions keep top-level sections at `##`
+  so GitHub's auto-TOC sidebar surfaces them — see
+  `docs/issue-filing-style.md` section "Heading levels for navigability".
 
 ## Public-Repo Leak Guard
 

--- a/skills/using-github/workflows/edit-issue.md
+++ b/skills/using-github/workflows/edit-issue.md
@@ -74,7 +74,7 @@ field the user wants to touch:
 | Field | Operation | Value |
 |---|---|---|
 | `title` | `set` | new title |
-| `body` | `set` | new body (full replacement) |
+| `body` | `set` | new body (full replacement; keep top-level sections at `##` per `docs/issue-filing-style.md` "Heading levels for navigability") |
 | `labels` | `add` / `remove` | label name(s) |
 | `assignees` | `add` / `remove` | login(s) |
 | `milestone` | `set` / `clear` | milestone title or `""` |

--- a/skills/using-github/workflows/new-issue.md
+++ b/skills/using-github/workflows/new-issue.md
@@ -317,6 +317,9 @@ Rules:
 - Keep "Out of Scope" present even if brief.
 - `## Non-Goals / Implementation Notes` is optional; do not add other unlisted
   sections.
+- Keep top-level body sections at `##` so GitHub's auto-TOC sidebar surfaces
+  them. Reserve `###` for tightly-coupled sub-sections. See
+  `docs/issue-filing-style.md` section "Heading levels for navigability".
 - If `$contextSuffix` is non-empty (from `related-to` entries in Step 6),
   append it to the `## Context` section before presenting the draft.
 - If `$depSupported = false` and any `blocked-by`/`blocks` entries exist, also

--- a/skills/using-github/workflows/pull-request.md
+++ b/skills/using-github/workflows/pull-request.md
@@ -106,6 +106,13 @@ Store the result as `$prTitle`.
 
 Build the body section-by-section using the headings captured in Step 2.
 
+**Heading levels.** Reproduce the template's section headings at the
+exact level the template uses (the top-level sections are `##`). Keep AC
+sub-rows at `### AC-<issue>-<n>`. See `docs/issue-filing-style.md`
+section "Heading levels for navigability" for the rule: GitHub's
+auto-TOC sidebar surfaces only `#`/`##`. Promote any sub-section that
+operators will want to jump to via the sidebar to `##`.
+
 **Linked issue.** Use `Closes #<issue>` when the PR completes the issue,
 `Related to #<issue>` otherwise. Omit the section if no issue applies.
 
@@ -267,6 +274,7 @@ Stop and do NOT open a PR if:
 | Mistake | Fix |
 |---------|-----|
 | Inventing PR section names | Reproduce the template headings verbatim, in source order |
+| Demoting top-level sections to `###` | Top-level sections must stay `##` so GitHub's auto-TOC sidebar surfaces them — see `docs/issue-filing-style.md` "Heading levels for navigability" |
 | Skipping the issue number in the title | `type: #N short description` is mandatory; ask the user if no branch-encoded issue |
 | Adding a scope like `feat(repo): …` | commitlint rejects scopes — drop them |
 | Including `⚠️ E2E gap` with placeholder text | Omit the row entirely when coverage is comprehensive |

--- a/skills/using-github/workflows/write-changelog.md
+++ b/skills/using-github/workflows/write-changelog.md
@@ -252,6 +252,12 @@ Render in this exact shape. **Breaking** appears first when present, then
 - **Title** – description ([#N](<issue-url>))
 ```
 
+The version heading uses `##` and the bucket headings use `###` deliberately:
+GitHub's auto-TOC sidebar surfaces only `#`/`##`, so each release stays
+sidebar-navigable while bucket sub-rows remain co-located under it. See
+`docs/issue-filing-style.md` "Heading levels for navigability". Do not promote
+buckets to `##` or demote the version heading.
+
 **Resolution rules:**
 
 - `<version>` defaults to `$milestoneTitle`.


### PR DESCRIPTION
## Summary

- Add a "Heading levels for navigability" section to `docs/issue-filing-style.md` covering the H2-min rule, the `###` exception for tightly-coupled sub-sections, and the GitHub anchor algorithm for manual in-body TOCs.
- Cross-reference the rule from the new-issue workflow, the pull-request workflow, and the `using-github` SKILL "Shared GitHub Rules".

## Linked issue

Closes #25

## Acceptance criteria

The issue lists three informal acceptance checkboxes rather than formal `AC-25-<n>` IDs. They are reproduced below as `AC-25-1`..`AC-25-3` for traceability.

### AC-25-1

Skill doc(s) updated with the H2-min rule and the GitHub anchor algorithm. `[platform: none]`

- [ ] Manual test: open `docs/issue-filing-style.md`; confirm the new `## Heading levels for navigability` section explains that GitHub's auto-TOC sidebar surfaces only `#`/`##`, recommends `##` for navigable sections, and includes the 4-step anchor algorithm with a worked example.

### AC-25-2

Issue-body and PR-body templates referenced in the skill mention the rule. `[platform: none]`

- [ ] Manual test: open `skills/using-github/workflows/new-issue.md` Step 7 "Draft and Present" and confirm the rules list links to the new section. Open `skills/using-github/workflows/pull-request.md` Step 4 "Draft body" and confirm the new "Heading levels" paragraph + the new "Common Mistakes" row both reference the section.

### AC-25-3

Cross-reference from agents that author long descriptions. `[platform: none]`

- [ ] Manual test: open `skills/using-github/SKILL.md`; confirm the "Shared GitHub Rules" list contains a bullet pointing at `docs/issue-filing-style.md` "Heading levels for navigability". The `superteam` Finisher / PR-body-template lives in another repo; opening a follow-up there is out of scope for `using-github`.

## Validation

- `pnpm lint:md` — passes (0 errors across 40 files).

## Docs updated

- [ ] Not needed
- [x] Updated in this PR
