### PR TITLE
docs: #32 link archived repo to skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # using-github
 
+> **Archive notice:** using-github now lives in
+> [`patinaproject/skills`](https://github.com/patinaproject/skills). Use that
+> repository for the current plugin, issues, and updates.
+
 One GitHub workflow skill for coding agents: file issues, edit issues, start
 branches, write changelogs, and prepare pull requests from repository rules.
 


### PR DESCRIPTION
## Summary

- Add an archive notice at the top of the README.
- Point visitors to `patinaproject/skills` for the current plugin, issues, and updates.

## Linked issue

- Related to #32. This PR completes the README handoff; repository archival must happen through the GitHub repository setting after merge.

## Acceptance criteria

### AC-32-1

Visitors can clearly navigate from this repository to the maintained `patinaproject/skills` repository.

- [x] Local evidence — pnpm lint:md | local clone | @tlmader | 2026-05-12T15:08:50Z
- [ ] Manual test: 1. Open the README on GitHub. 2. Confirm the archive notice appears at the top. 3. Confirm the `patinaproject/skills` link opens https://github.com/patinaproject/skills.

### AC-32-2

Deferred until after this PR merges because archiving is a repository setting, not a file change.

## Validation

- `pnpm lint:md`
- Commit hook ran `markdownlint-cli2` on the staged README and `pnpm check:versions`.

## Docs updated

- [x] Updated in this PR